### PR TITLE
Ignore untracked files during terminal update

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -1405,7 +1405,7 @@ async function installUpdate(): Promise<UpdateStatus> {
 
   try {
     const cwd = process.cwd();
-    const dirty = (await runTerminalCommand("git", ["status", "--porcelain"], cwd)).trim();
+    const dirty = (await runTerminalCommand("git", ["status", "--porcelain", "--untracked-files=no"], cwd)).trim();
     if (dirty) {
       throw new Error(mainText("dirtyWorkspace"));
     }


### PR DESCRIPTION
﻿## Summary

- Allow the in-app terminal updater to proceed when the only workspace changes are untracked local files.
- Keep protection for tracked local edits so real user changes still block terminal updates.

## Why

The updater currently runs `git status --porcelain`, which treats local editor settings and generated preview files as dirty workspace state. That blocks updates even when no tracked project files were changed.

## Validation

- `npm run typecheck`
- `npm run build`
