### PR TITLE
Mark shared Electron build output as CommonJS

### DIFF
--- a/scripts/copy-preload.mjs
+++ b/scripts/copy-preload.mjs
@@ -7,18 +7,26 @@ const rootPkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "ut
 
 mkdirSync(dirname(to), { recursive: true });
 copyFileSync(from, to);
-writeFileSync(
-  join(process.cwd(), "dist/electron/package.json"),
-  JSON.stringify(
-    {
-      name: rootPkg.name,
-      productName: rootPkg.productName,
-      version: rootPkg.version,
-      main: "main.js",
-      type: "commonjs",
-    },
-    null,
-    2,
-  ),
-  "utf8",
-);
+
+writeCommonJsPackage("dist/electron", { main: "main.js" });
+writeCommonJsPackage("dist/shared");
+
+function writeCommonJsPackage(directory, extra = {}) {
+  const target = join(process.cwd(), directory);
+  mkdirSync(target, { recursive: true });
+  writeFileSync(
+    join(target, "package.json"),
+    JSON.stringify(
+      {
+        name: rootPkg.name,
+        productName: rootPkg.productName,
+        version: rootPkg.version,
+        type: "commonjs",
+        ...extra,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}


### PR DESCRIPTION
﻿## Summary

- Mark `dist/shared` as CommonJS during the Electron build.
- Keep the existing Electron build metadata for `dist/electron`.
- Fix the main-process crash after v0.3.3 imports shared token accounting from Electron code.

## Why

`src/shared/tokenAccounting.ts` is now imported by Electron main code. The Electron compiler emits CommonJS, but the compiled shared file lives under `dist/shared`. Without a local `dist/shared/package.json`, Node follows the root package metadata and treats `.js` files as ESM because the root package has `"type": "module"`. That makes `require("../shared/tokenAccounting.js")` crash at startup.

## Validation

- `npm run typecheck`
- `npm run build`
- Restarted the local Electron app successfully after the build
