### PR TITLE
fix(electron): support OpenCode SQLite storage

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -82,7 +82,7 @@ electron_mirror=https://npmmirror.com/mirrors/electron/
 | Codex | ✅ | `~/.codex/sessions/**/*.jsonl` |
 | Claude Code | ✅ | `~/.claude/projects/**/*.jsonl` |
 | OpenClaw | ✅ | `~/.openclaw/agents/**/sessions/*.jsonl` |
-| OpenCode | ✅ | `~/.local/share/opencode/storage/message/**/*.json` |
+| OpenCode | ✅ | `~/.local/share/opencode/opencode.db` (legacy `storage/message/**/*.json` remains supported) |
 | Gemini | ✅ | local Gemini session directory |
 | Hermes | ✅ | local Hermes session directory |
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ electron_mirror=https://npmmirror.com/mirrors/electron/
 | Codex | ✅ | `~/.codex/sessions/**/*.jsonl` |
 | Claude Code | ✅ | `~/.claude/projects/**/*.jsonl` |
 | OpenClaw | ✅ | `~/.openclaw/agents/**/sessions/*.jsonl` |
-| OpenCode | ✅ | `~/.local/share/opencode/storage/message/**/*.json` |
+| OpenCode | ✅ | `~/.local/share/opencode/opencode.db`（兼容旧版 `storage/message/**/*.json`） |
 | Gemini | ✅ | 本地 Gemini 会话目录 |
 | Hermes | ✅ | 本地 Hermes 会话目录 |
 

--- a/src/electron/agentSessionWatchers.ts
+++ b/src/electron/agentSessionWatchers.ts
@@ -75,10 +75,17 @@ interface HermesSessionRow {
   reasoning_tokens?: number;
 }
 
+interface OpenCodeMessageRow {
+  id: string;
+  session_id: string;
+  time_created: number;
+  data: string;
+}
+
 const READ_CHUNK_SIZE = 64 * 1024;
 const DEFAULT_CLAUDE_ROOT = join(homedir(), ".claude", "projects");
 const DEFAULT_OPENCLAW_ROOT = join(homedir(), ".openclaw", "agents");
-const DEFAULT_OPENCODE_MESSAGES_ROOT = defaultOpenCodeMessagesRoot();
+const DEFAULT_OPENCODE_DB = defaultOpenCodeDbPath();
 const DEFAULT_GEMINI_ROOT = join(homedir(), ".gemini", "tmp");
 const DEFAULT_HERMES_STATE_DB = join(homedir(), ".hermes", "state.db");
 
@@ -107,16 +114,66 @@ export function startOpenClawSessionWatcher(options: SessionWatcherOptions) {
 }
 
 export function startOpenCodeSessionWatcher(options: SessionWatcherOptions) {
-  return startJsonAgentSessionWatcher(options, {
-    source: "opencode-session",
-    agent: "opencode",
-    sessionsRoot: options.sessionsRoot || process.env.VIBE_OPENCODE_SESSIONS_DIR || DEFAULT_OPENCODE_MESSAGES_ROOT,
-    importHistoryEnv: "VIBE_OPENCODE_IMPORT_HISTORY",
-    stateFileName: "opencode-session-watcher.json",
-    pollIntervalMs: 10_000,
-    fileExtensions: [".json"],
-    parseFile: parseOpenCodeFile,
-  });
+  const dbPath = options.sessionsRoot || process.env.VIBE_OPENCODE_SESSIONS_DIR || DEFAULT_OPENCODE_DB;
+  const historyStartAtMs = timestampMs(options.historyStartAt);
+  const importHistory = process.env.VIBE_OPENCODE_IMPORT_HISTORY === "today" || Boolean(historyStartAtMs);
+  const statePath = join(options.userDataPath, "opencode-session-watcher.json");
+  const state = readState(statePath);
+  if (state.historyStartAt !== options.historyStartAt) {
+    state.files = {};
+    state.events = {};
+    state.historyStartAt = options.historyStartAt;
+  }
+  const watcherStartedAt = Date.now();
+  const status: SessionMonitorStatus = {
+    running: true,
+    sessionsRoot: dbPath,
+    exists: existsSync(dbPath),
+    filesWatched: 0,
+    eventsImported: 0,
+    importHistory,
+    historyStartAt: options.historyStartAt,
+  };
+
+  let closed = false;
+
+  const poll = () => {
+    if (closed) return;
+    status.exists = existsSync(dbPath);
+    status.filesWatched = status.exists ? 1 : 0;
+    status.lastScanAt = new Date().toISOString();
+    if (!status.exists) {
+      options.onStatus?.(status);
+      return;
+    }
+
+    const imported = scanOpenCodeDb(
+      dbPath,
+      state,
+      statePath,
+      { importHistory, watcherStartedAt, historyStartAtMs },
+      options.onUsage,
+    );
+    if (imported > 0) {
+      status.eventsImported += imported;
+      status.lastEventAt = new Date().toISOString();
+    }
+    options.onStatus?.(status);
+  };
+
+  poll();
+  const timer = setInterval(poll, 10_000);
+
+  return {
+    close: () => {
+      closed = true;
+      status.running = false;
+      clearInterval(timer);
+      writeState(statePath, state);
+      options.onStatus?.(status);
+    },
+    getStatus: () => status,
+  };
 }
 
 export function startGeminiSessionWatcher(options: SessionWatcherOptions) {
@@ -464,6 +521,108 @@ function scanHermesStateDb(
 
   writeState(statePath, state);
   return imported;
+}
+
+function scanOpenCodeDb(
+  dbPath: string,
+  state: WatchState,
+  statePath: string,
+  settings: { importHistory: boolean; watcherStartedAt: number; historyStartAtMs?: number },
+  onUsage: (event: UsageEvent) => void,
+) {
+  const stats = statSync(dbPath);
+  const previousMtime = state.files[dbPath];
+  if (previousMtime !== undefined && stats.mtimeMs <= previousMtime) {
+    return 0;
+  }
+
+  const rows = readOpenCodeMessageRows(dbPath);
+  if (!rows) {
+    return 0;
+  }
+  state.files[dbPath] = stats.mtimeMs;
+
+  let imported = 0;
+  for (const row of rows) {
+    const messageId = stringValue(row.id);
+    if (!messageId) continue;
+
+    const parsed = parseJson(row.data);
+    if (!parsed || parsed.role !== "assistant") continue;
+
+    const event = parseOpenCodeMessageData(parsed, row);
+    if (!event || !usageEventHasTokens(event)) continue;
+
+    const createdAt = event.createdAt;
+    const isHistorical = isBeforeHistoryStart(createdAt, settings.historyStartAtMs);
+    if (isHistorical) continue;
+
+    if (state.events[event.id]) continue;
+    state.events[event.id] = true;
+    onUsage(event);
+    imported += 1;
+  }
+
+  writeState(statePath, state);
+  return imported;
+}
+
+function readOpenCodeMessageRows(dbPath: string): OpenCodeMessageRow[] | undefined {
+  const query = `
+    SELECT id, session_id, time_created, data
+    FROM message
+    WHERE json_extract(data, '$.role') = 'assistant'
+      AND (
+        json_extract(data, '$.tokens.input') > 0
+        OR json_extract(data, '$.tokens.output') > 0
+        OR json_extract(data, '$.tokens.reasoning') > 0
+      )
+  `;
+  try {
+    const output = execFileSync("sqlite3", ["-json", dbPath, query], {
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    const parsed = JSON.parse(output || "[]");
+    return Array.isArray(parsed) ? (parsed as OpenCodeMessageRow[]) : [];
+  } catch {
+    return undefined;
+  }
+}
+
+function parseOpenCodeMessageData(parsed: Record<string, unknown>, row: OpenCodeMessageRow): UsageEvent | undefined {
+  const tokens = asRecord(parsed.tokens);
+  if (!tokens) return undefined;
+
+  const cache = asRecord(tokens.cache);
+  const inputTokens = numberValue(tokens.input);
+  const outputTokens = numberValue(tokens.output) + numberValue(tokens.reasoning);
+  const cacheReadTokens = numberValue(cache?.read);
+  const cacheWriteTokens = numberValue(cache?.write);
+  const totalTokens = inputTokens + outputTokens;
+  if (totalTokens <= 0) return undefined;
+
+  const messageId = stringValue(parsed.id) || stringValue(row.id);
+  const sessionId = stringValue(parsed.sessionID) || stringValue(parsed.sessionId) || stringValue(row.session_id);
+  const provider = stringValue(parsed.providerID) || stringValue(parsed.providerId) || "opencode";
+  const model = stringValue(parsed.modelID) || stringValue(parsed.modelId);
+  const agentName = stringValue(parsed.agent);
+  const time = asRecord(parsed.time);
+
+  return {
+    id: `opencode-session:${hash(`${sessionId ?? "unknown"}:${messageId}`)}`,
+    createdAt: timestampToIso(time?.completed) || timestampToIso(time?.created) || timestampToIso(row.time_created) || new Date().toISOString(),
+    source: "opencode-session",
+    agent: agentName ? `opencode:${agentName}` : "opencode",
+    provider,
+    model,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    totalTokens,
+    streaming: false,
+  };
 }
 
 function scanNewLines(filePath: string, start: number, end: number, onLine: (line: string, lineOffset: number) => number) {
@@ -958,12 +1117,12 @@ function isTodaySessionPath(filePath: string) {
   return false;
 }
 
-function defaultOpenCodeMessagesRoot() {
+function defaultOpenCodeDbPath() {
   if (process.env.XDG_DATA_HOME) {
-    return join(process.env.XDG_DATA_HOME, "opencode", "storage", "message");
+    return join(process.env.XDG_DATA_HOME, "opencode", "opencode.db");
   }
   if (process.platform === "win32" && process.env.LOCALAPPDATA) {
-    return join(process.env.LOCALAPPDATA, "opencode", "storage", "message");
+    return join(process.env.LOCALAPPDATA, "opencode", "opencode.db");
   }
-  return join(homedir(), ".local", "share", "opencode", "storage", "message");
+  return join(homedir(), ".local", "share", "opencode", "opencode.db");
 }

--- a/src/electron/agentSessionWatchers.ts
+++ b/src/electron/agentSessionWatchers.ts
@@ -79,13 +79,28 @@ interface OpenCodeMessageRow {
   id: string;
   session_id: string;
   time_created: number;
-  data: string;
+  data_id?: string;
+  data_session_id?: string;
+  data_session_id_legacy?: string;
+  provider_id?: string;
+  provider_id_legacy?: string;
+  model_id?: string;
+  model_id_legacy?: string;
+  agent?: string;
+  created_at?: string | number;
+  completed_at?: string | number;
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
 }
 
 const READ_CHUNK_SIZE = 64 * 1024;
 const DEFAULT_CLAUDE_ROOT = join(homedir(), ".claude", "projects");
 const DEFAULT_OPENCLAW_ROOT = join(homedir(), ".openclaw", "agents");
 const DEFAULT_OPENCODE_DB = defaultOpenCodeDbPath();
+const DEFAULT_OPENCODE_MESSAGES_ROOT = defaultOpenCodeMessagesRoot();
 const DEFAULT_GEMINI_ROOT = join(homedir(), ".gemini", "tmp");
 const DEFAULT_HERMES_STATE_DB = join(homedir(), ".hermes", "state.db");
 
@@ -114,7 +129,23 @@ export function startOpenClawSessionWatcher(options: SessionWatcherOptions) {
 }
 
 export function startOpenCodeSessionWatcher(options: SessionWatcherOptions) {
-  const dbPath = options.sessionsRoot || process.env.VIBE_OPENCODE_SESSIONS_DIR || DEFAULT_OPENCODE_DB;
+  const target = openCodeWatcherTarget(options.sessionsRoot || process.env.VIBE_OPENCODE_SESSIONS_DIR);
+  if (target.kind === "json") {
+    return startJsonAgentSessionWatcher(options, {
+      source: "opencode-session",
+      agent: "opencode",
+      sessionsRoot: target.path,
+      importHistoryEnv: "VIBE_OPENCODE_IMPORT_HISTORY",
+      stateFileName: "opencode-session-watcher.json",
+      pollIntervalMs: 10_000,
+      fileExtensions: [".json"],
+      parseFile: parseOpenCodeFile,
+    });
+  }
+  return startOpenCodeDbSessionWatcher(options, target.path);
+}
+
+function startOpenCodeDbSessionWatcher(options: SessionWatcherOptions, dbPath: string) {
   const historyStartAtMs = timestampMs(options.historyStartAt);
   const importHistory = process.env.VIBE_OPENCODE_IMPORT_HISTORY === "today" || Boolean(historyStartAtMs);
   const statePath = join(options.userDataPath, "opencode-session-watcher.json");
@@ -147,13 +178,7 @@ export function startOpenCodeSessionWatcher(options: SessionWatcherOptions) {
       return;
     }
 
-    const imported = scanOpenCodeDb(
-      dbPath,
-      state,
-      statePath,
-      { importHistory, watcherStartedAt, historyStartAtMs },
-      options.onUsage,
-    );
+    const imported = scanOpenCodeDb(dbPath, state, statePath, { importHistory, watcherStartedAt, historyStartAtMs }, options.onUsage);
     if (imported > 0) {
       status.eventsImported += imported;
       status.lastEventAt = new Date().toISOString();
@@ -530,9 +555,9 @@ function scanOpenCodeDb(
   settings: { importHistory: boolean; watcherStartedAt: number; historyStartAtMs?: number },
   onUsage: (event: UsageEvent) => void,
 ) {
-  const stats = statSync(dbPath);
+  const currentMtime = sqliteDbScanMtime(dbPath);
   const previousMtime = state.files[dbPath];
-  if (previousMtime !== undefined && stats.mtimeMs <= previousMtime) {
+  if (previousMtime !== undefined && currentMtime <= previousMtime) {
     return 0;
   }
 
@@ -540,25 +565,16 @@ function scanOpenCodeDb(
   if (!rows) {
     return 0;
   }
-  state.files[dbPath] = stats.mtimeMs;
+  state.files[dbPath] = currentMtime;
 
   let imported = 0;
   for (const row of rows) {
-    const messageId = stringValue(row.id);
-    if (!messageId) continue;
-
-    const parsed = parseJson(row.data);
-    if (!parsed || parsed.role !== "assistant") continue;
-
-    const event = parseOpenCodeMessageData(parsed, row);
+    const event = parseOpenCodeMessageRow(row);
     if (!event || !usageEventHasTokens(event)) continue;
-
-    const createdAt = event.createdAt;
-    const isHistorical = isBeforeHistoryStart(createdAt, settings.historyStartAtMs);
-    if (isHistorical) continue;
 
     if (state.events[event.id]) continue;
     state.events[event.id] = true;
+    if (!shouldImportOpenCodeDbEvent(event.createdAt, previousMtime === undefined, settings)) continue;
     onUsage(event);
     imported += 1;
   }
@@ -569,14 +585,35 @@ function scanOpenCodeDb(
 
 function readOpenCodeMessageRows(dbPath: string): OpenCodeMessageRow[] | undefined {
   const query = `
-    SELECT id, session_id, time_created, data
+    SELECT
+      id,
+      session_id,
+      time_created,
+      json_extract(data, '$.id') AS data_id,
+      json_extract(data, '$.sessionId') AS data_session_id,
+      json_extract(data, '$.sessionID') AS data_session_id_legacy,
+      json_extract(data, '$.providerId') AS provider_id,
+      json_extract(data, '$.providerID') AS provider_id_legacy,
+      json_extract(data, '$.modelId') AS model_id,
+      json_extract(data, '$.modelID') AS model_id_legacy,
+      json_extract(data, '$.agent') AS agent,
+      json_extract(data, '$.time.created') AS created_at,
+      json_extract(data, '$.time.completed') AS completed_at,
+      json_extract(data, '$.tokens.input') AS input_tokens,
+      json_extract(data, '$.tokens.output') AS output_tokens,
+      json_extract(data, '$.tokens.reasoning') AS reasoning_tokens,
+      json_extract(data, '$.tokens.cache.read') AS cache_read_tokens,
+      json_extract(data, '$.tokens.cache.write') AS cache_write_tokens
     FROM message
     WHERE json_extract(data, '$.role') = 'assistant'
       AND (
         json_extract(data, '$.tokens.input') > 0
         OR json_extract(data, '$.tokens.output') > 0
         OR json_extract(data, '$.tokens.reasoning') > 0
+        OR json_extract(data, '$.tokens.cache.read') > 0
+        OR json_extract(data, '$.tokens.cache.write') > 0
       )
+    ORDER BY time_created ASC, id ASC
   `;
   try {
     const output = execFileSync("sqlite3", ["-json", dbPath, query], {
@@ -590,28 +627,23 @@ function readOpenCodeMessageRows(dbPath: string): OpenCodeMessageRow[] | undefin
   }
 }
 
-function parseOpenCodeMessageData(parsed: Record<string, unknown>, row: OpenCodeMessageRow): UsageEvent | undefined {
-  const tokens = asRecord(parsed.tokens);
-  if (!tokens) return undefined;
-
-  const cache = asRecord(tokens.cache);
-  const inputTokens = numberValue(tokens.input);
-  const outputTokens = numberValue(tokens.output) + numberValue(tokens.reasoning);
-  const cacheReadTokens = numberValue(cache?.read);
-  const cacheWriteTokens = numberValue(cache?.write);
+function parseOpenCodeMessageRow(row: OpenCodeMessageRow): UsageEvent | undefined {
+  const inputTokens = numberValue(row.input_tokens);
+  const outputTokens = numberValue(row.output_tokens) + numberValue(row.reasoning_tokens);
+  const cacheReadTokens = numberValue(row.cache_read_tokens);
+  const cacheWriteTokens = numberValue(row.cache_write_tokens);
   const totalTokens = inputTokens + outputTokens;
-  if (totalTokens <= 0) return undefined;
+  if (totalTokens + cacheReadTokens + cacheWriteTokens <= 0) return undefined;
 
-  const messageId = stringValue(parsed.id) || stringValue(row.id);
-  const sessionId = stringValue(parsed.sessionID) || stringValue(parsed.sessionId) || stringValue(row.session_id);
-  const provider = stringValue(parsed.providerID) || stringValue(parsed.providerId) || "opencode";
-  const model = stringValue(parsed.modelID) || stringValue(parsed.modelId);
-  const agentName = stringValue(parsed.agent);
-  const time = asRecord(parsed.time);
+  const messageId = stringValue(row.data_id) || stringValue(row.id);
+  const sessionId = stringValue(row.data_session_id) || stringValue(row.data_session_id_legacy) || stringValue(row.session_id);
+  const provider = stringValue(row.provider_id) || stringValue(row.provider_id_legacy) || "opencode";
+  const model = stringValue(row.model_id) || stringValue(row.model_id_legacy);
+  const agentName = stringValue(row.agent);
 
   return {
     id: `opencode-session:${hash(`${sessionId ?? "unknown"}:${messageId}`)}`,
-    createdAt: timestampToIso(time?.completed) || timestampToIso(time?.created) || timestampToIso(row.time_created) || new Date().toISOString(),
+    createdAt: timestampToIso(row.completed_at) || timestampToIso(row.created_at) || timestampToIso(row.time_created) || new Date().toISOString(),
     source: "opencode-session",
     agent: agentName ? `opencode:${agentName}` : "opencode",
     provider,
@@ -623,6 +655,21 @@ function parseOpenCodeMessageData(parsed: Record<string, unknown>, row: OpenCode
     totalTokens,
     streaming: false,
   };
+}
+
+function shouldImportOpenCodeDbEvent(
+  createdAt: string,
+  isInitialScan: boolean,
+  settings: { importHistory: boolean; watcherStartedAt: number; historyStartAtMs?: number },
+) {
+  if (isBeforeHistoryStart(createdAt, settings.historyStartAtMs)) return false;
+  if (!isInitialScan) return true;
+
+  const createdAtMs = timestampMs(createdAt);
+  if (!createdAtMs) return false;
+  if (settings.historyStartAtMs) return createdAtMs >= settings.historyStartAtMs - 5_000;
+  if (settings.importHistory) return isTodayTimestamp(createdAtMs);
+  return createdAtMs >= settings.watcherStartedAt - 5_000;
 }
 
 function scanNewLines(filePath: string, start: number, end: number, onLine: (line: string, lineOffset: number) => number) {
@@ -1117,6 +1164,45 @@ function isTodaySessionPath(filePath: string) {
   return false;
 }
 
+function openCodeWatcherTarget(configuredPath: string | undefined): { kind: "sqlite" | "json"; path: string } {
+  if (configuredPath) {
+    const directoryDbPath = join(configuredPath, "opencode.db");
+    if (isSqliteDbPath(configuredPath) || isFile(configuredPath)) {
+      return { kind: "sqlite", path: configuredPath };
+    }
+    if (existsSync(directoryDbPath)) {
+      return { kind: "sqlite", path: directoryDbPath };
+    }
+    return { kind: "json", path: configuredPath };
+  }
+
+  if (existsSync(DEFAULT_OPENCODE_DB) || !existsSync(DEFAULT_OPENCODE_MESSAGES_ROOT)) {
+    return { kind: "sqlite", path: DEFAULT_OPENCODE_DB };
+  }
+  return { kind: "json", path: DEFAULT_OPENCODE_MESSAGES_ROOT };
+}
+
+function sqliteDbScanMtime(dbPath: string) {
+  let mtimeMs = statSync(dbPath).mtimeMs;
+  for (const siblingPath of [`${dbPath}-wal`, `${dbPath}-shm`]) {
+    if (!existsSync(siblingPath)) continue;
+    mtimeMs = Math.max(mtimeMs, statSync(siblingPath).mtimeMs);
+  }
+  return mtimeMs;
+}
+
+function isSqliteDbPath(path: string) {
+  return /\.db(?:3|)$/i.test(path);
+}
+
+function isFile(path: string) {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
 function defaultOpenCodeDbPath() {
   if (process.env.XDG_DATA_HOME) {
     return join(process.env.XDG_DATA_HOME, "opencode", "opencode.db");
@@ -1125,4 +1211,14 @@ function defaultOpenCodeDbPath() {
     return join(process.env.LOCALAPPDATA, "opencode", "opencode.db");
   }
   return join(homedir(), ".local", "share", "opencode", "opencode.db");
+}
+
+function defaultOpenCodeMessagesRoot() {
+  if (process.env.XDG_DATA_HOME) {
+    return join(process.env.XDG_DATA_HOME, "opencode", "storage", "message");
+  }
+  if (process.platform === "win32" && process.env.LOCALAPPDATA) {
+    return join(process.env.LOCALAPPDATA, "opencode", "storage", "message");
+  }
+  return join(homedir(), ".local", "share", "opencode", "storage", "message");
 }

--- a/src/renderer/appShell.ts
+++ b/src/renderer/appShell.ts
@@ -380,7 +380,7 @@ export function appShellHtml(viewMode: ViewMode) {
                   <input type="checkbox" data-stats-source="opencode" />
                   <span data-i18n="opencodePath">OpenCode 路径</span>
                 </label>
-                <input id="opencodeSessionsDirInput" type="text" placeholder="~/.local/share/opencode/storage/message" aria-label="OpenCode path" />
+                <input id="opencodeSessionsDirInput" type="text" placeholder="~/.local/share/opencode/opencode.db" aria-label="OpenCode path" />
               </div>
               <div class="agent-source-row">
                 <label class="agent-source-toggle">


### PR DESCRIPTION
- Change default path from storage/message to opencode.db
- Add SQLite database reading using sqlite3 CLI (no npm deps)
- Add scanOpenCodeDb and readOpenCodeMessageRows functions
- Parse message table data field as JSON (compatible structure)
- Track processed message IDs to avoid duplicate events

Fixes #XX (OpenCode data source import issue)