### PR TITLE
Add Pi Agent token statistics support

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -32,7 +32,7 @@ Opt into the leaderboard with GitHub. By default, only aggregated token ranking 
 
 - **Desktop pixel tree**: always-on-top, draggable, scalable, lockable, and quiet on startup.
 - **Live token weather**: total tokens drive level growth; current token/min drives weather.
-- **Multi-agent sources**: Codex, Claude Code, OpenClaw, OpenCode, Gemini, and Hermes.
+- **Multi-agent sources**: Codex, Claude Code, OpenClaw, Pi Agent, OpenCode, Gemini, and Hermes.
 - **Source and model breakdowns**: inspect input, output, cache, and model distribution by agent.
 - **Recent 7-day chart**: filter token trends by source.
 - **Achievements**: unlock milestones for totals, peaks, streaks, time habits, and agent usage.
@@ -82,6 +82,7 @@ electron_mirror=https://npmmirror.com/mirrors/electron/
 | Codex | ✅ | `~/.codex/sessions/**/*.jsonl` |
 | Claude Code | ✅ | `~/.claude/projects/**/*.jsonl` |
 | OpenClaw | ✅ | `~/.openclaw/agents/**/sessions/*.jsonl` |
+| Pi Agent | ✅ | `~/.pi/agent/sessions/**/*.jsonl` |
 | OpenCode | ✅ | `~/.local/share/opencode/opencode.db` (legacy `storage/message/**/*.json` remains supported) |
 | Gemini | ✅ | local Gemini session directory |
 | Hermes | ✅ | local Hermes session directory |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Vibe Tree 是一个桌面常驻的 token 天气树。它会读取本地 AI codin
 
 - **桌面像素树**：常驻桌面，支持置顶、拖动、缩放、锁定位置和静默启动。
 - **实时 token 天气**：累计 Token 决定成长等级，当前 token/min 决定天气状态。
-- **多 Agent 数据源**：支持 Codex、Claude Code、OpenClaw、OpenCode、Gemini 和 Hermes。
+- **多 Agent 数据源**：支持 Codex、Claude Code、OpenClaw、Pi Agent、OpenCode、Gemini 和 Hermes。
 - **来源与模型统计**：按 agent 查看 input / output / cache，展开后可查看模型占比。
 - **最近 7 天图表**：按来源筛选近期 token 使用趋势。
 - **成就系统**：记录累计消耗、峰值时刻、连续活跃、时间偏好和 agent 使用里程碑。
@@ -82,6 +82,7 @@ electron_mirror=https://npmmirror.com/mirrors/electron/
 | Codex | ✅ | `~/.codex/sessions/**/*.jsonl` |
 | Claude Code | ✅ | `~/.claude/projects/**/*.jsonl` |
 | OpenClaw | ✅ | `~/.openclaw/agents/**/sessions/*.jsonl` |
+| Pi Agent | ✅ | `~/.pi/agent/sessions/**/*.jsonl` |
 | OpenCode | ✅ | `~/.local/share/opencode/opencode.db`（兼容旧版 `storage/message/**/*.json`） |
 | Gemini | ✅ | 本地 Gemini 会话目录 |
 | Hermes | ✅ | 本地 Hermes 会话目录 |

--- a/src/electron/agentSessionWatchers.ts
+++ b/src/electron/agentSessionWatchers.ts
@@ -41,8 +41,8 @@ interface UsageSnapshot {
 }
 
 interface AgentConfig {
-  source: "claude-session" | "openclaw-session";
-  agent: "claude-code" | "openclaw";
+  source: "claude-session" | "openclaw-session" | "pi-session";
+  agent: "claude-code" | "openclaw" | "pi-agent";
   sessionsRoot: string;
   importHistoryEnv: string;
   stateFileName: string;
@@ -99,6 +99,7 @@ interface OpenCodeMessageRow {
 const READ_CHUNK_SIZE = 64 * 1024;
 const DEFAULT_CLAUDE_ROOT = join(homedir(), ".claude", "projects");
 const DEFAULT_OPENCLAW_ROOT = join(homedir(), ".openclaw", "agents");
+const DEFAULT_PI_ROOT = defaultPiSessionsRoot();
 const DEFAULT_OPENCODE_DB = defaultOpenCodeDbPath();
 const DEFAULT_OPENCODE_MESSAGES_ROOT = defaultOpenCodeMessagesRoot();
 const DEFAULT_GEMINI_ROOT = join(homedir(), ".gemini", "tmp");
@@ -125,6 +126,19 @@ export function startOpenClawSessionWatcher(options: SessionWatcherOptions) {
     stateFileName: "openclaw-session-watcher.json",
     pollIntervalMs: 10_000,
     parseLine: parseOpenClawLine,
+  });
+}
+
+export function startPiSessionWatcher(options: SessionWatcherOptions) {
+  return startAgentSessionWatcher(options, {
+    source: "pi-session",
+    agent: "pi-agent",
+    sessionsRoot:
+      options.sessionsRoot || process.env.VIBE_PI_AGENT_SESSIONS_DIR || process.env.VIBE_PI_SESSIONS_DIR || DEFAULT_PI_ROOT,
+    importHistoryEnv: "VIBE_PI_IMPORT_HISTORY",
+    stateFileName: "pi-session-watcher.json",
+    pollIntervalMs: 10_000,
+    parseLine: parsePiLine,
   });
 }
 
@@ -776,6 +790,37 @@ function parseOpenClawLine(line: string, filePath: string, lineOffset: number): 
   };
 }
 
+function parsePiLine(line: string, filePath: string, lineOffset: number): UsageEvent | undefined {
+  const parsed = parseJson(line);
+  if (!parsed || parsed.type !== "message") return undefined;
+
+  const message = asRecord(parsed.message);
+  if (!message || message.role !== "assistant") return undefined;
+
+  const usage = asRecord(message.usage);
+  const tokens = parseOpenClawUsage(usage);
+  if (!tokens) return undefined;
+
+  const messageId = stringValue(parsed.id) || hash(`${filePath}:${lineOffset}`);
+  const provider = stringValue(message.provider) || "pi-agent";
+  const model = stringValue(message.model);
+
+  return {
+    id: `pi-session:${hash(`${filePath}:${messageId}`)}`,
+    createdAt: stringValue(parsed.timestamp) || new Date().toISOString(),
+    source: "pi-session",
+    agent: "pi-agent",
+    provider,
+    model,
+    inputTokens: tokens.inputTokens,
+    outputTokens: tokens.outputTokens,
+    cacheReadTokens: tokens.cacheReadTokens,
+    cacheWriteTokens: tokens.cacheWriteTokens,
+    totalTokens: tokens.inputTokens + tokens.outputTokens,
+    streaming: false,
+  };
+}
+
 function parseOpenCodeFile(filePath: string): UsageEvent | undefined {
   const parsed = readJsonFile(filePath);
   if (!parsed || parsed.role !== "assistant") return undefined;
@@ -1221,4 +1266,12 @@ function defaultOpenCodeMessagesRoot() {
     return join(process.env.LOCALAPPDATA, "opencode", "storage", "message");
   }
   return join(homedir(), ".local", "share", "opencode", "storage", "message");
+}
+
+function defaultPiSessionsRoot() {
+  const piAgentDir = process.env.PI_AGENT_DIR?.trim();
+  if (piAgentDir) return piAgentDir;
+  const piCodingAgentDir = process.env.PI_CODING_AGENT_DIR?.trim();
+  if (piCodingAgentDir) return join(piCodingAgentDir, "sessions");
+  return join(homedir(), ".pi", "agent", "sessions");
 }

--- a/src/electron/leaderboard.ts
+++ b/src/electron/leaderboard.ts
@@ -584,6 +584,7 @@ const LEADERBOARD_PREFERENCE_RANGES: LeaderboardRange[] = ["today", "7d", "30d",
 const AGENT_LABELS: Record<string, string> = {
   codex: "Codex",
   openclaw: "OpenClaw",
+  pi: "Pi Agent",
   opencode: "OpenCode",
   claude: "Claude Code",
   gemini: "Gemini",
@@ -644,6 +645,7 @@ function agentLabelForEntry(entry: LedgerEntry) {
 function preferenceSourceIdForEntry(entry: LedgerEntry): keyof typeof AGENT_LABELS | undefined {
   if (entry.source === "codex-session" || entry.agent === "codex-desktop") return "codex";
   if (entry.source === "openclaw-session" || entry.agent === "openclaw") return "openclaw";
+  if (entry.source === "pi-session" || entry.agent === "pi-agent") return "pi";
   if (entry.source === "opencode-session" || entry.agent === "opencode" || Boolean(entry.agent?.startsWith("opencode:"))) {
     return "opencode";
   }

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -24,6 +24,7 @@ import {
   startHermesSessionWatcher,
   startOpenClawSessionWatcher,
   startOpenCodeSessionWatcher,
+  startPiSessionWatcher,
 } from "./agentSessionWatchers.js";
 import { startCodexSessionWatcher } from "./codexSessionWatcher.js";
 import { MAIN_TEXT, WEATHER_LABELS } from "./i18n.js";
@@ -61,7 +62,7 @@ const MANAGER_MIN_SIZE = { width: 860, height: 620 };
 const APP_NAME = "Vibe Tree";
 const APP_ID = "com.vibetree.app";
 const SMOKE_TEST = process.env.VIBE_TREE_SMOKE_TEST === "1";
-const STAT_SOURCE_IDS = ["codex", "openclaw", "opencode", "claude", "gemini", "hermes"] as const;
+const STAT_SOURCE_IDS = ["codex", "openclaw", "pi", "opencode", "claude", "gemini", "hermes"] as const;
 const APP_ICON_PATHS = [
   join(__dirname, "../renderer/assets/app-icon.png"),
   join(__dirname, "../renderer/assets/app-icon.ico"),
@@ -129,6 +130,7 @@ let achievementState: AchievementState = { unlocked: [] };
 let codexSessionWatcher: ReturnType<typeof startCodexSessionWatcher> | null = null;
 let claudeSessionWatcher: ReturnType<typeof startClaudeSessionWatcher> | null = null;
 let openclawSessionWatcher: ReturnType<typeof startOpenClawSessionWatcher> | null = null;
+let piSessionWatcher: ReturnType<typeof startPiSessionWatcher> | null = null;
 let opencodeSessionWatcher: ReturnType<typeof startOpenCodeSessionWatcher> | null = null;
 let geminiSessionWatcher: ReturnType<typeof startGeminiSessionWatcher> | null = null;
 let hermesSessionWatcher: ReturnType<typeof startHermesSessionWatcher> | null = null;
@@ -149,6 +151,14 @@ let claudeSessionStatus: UsageStatus["claudeSession"] = {
   importHistory: false,
 };
 let openclawSessionStatus: UsageStatus["openclawSession"] = {
+  running: false,
+  sessionsRoot: "",
+  exists: false,
+  filesWatched: 0,
+  eventsImported: 0,
+  importHistory: false,
+};
+let piSessionStatus: UsageStatus["piSession"] = {
   running: false,
   sessionsRoot: "",
   exists: false,
@@ -508,6 +518,7 @@ function normalizeSettings(settings: Partial<Settings>): Settings {
     codexSessionsDir: cleanPath(settings.codexSessionsDir),
     claudeSessionsDir: cleanPath(settings.claudeSessionsDir),
     openclawSessionsDir: cleanPath(settings.openclawSessionsDir),
+    piSessionsDir: cleanPath(settings.piSessionsDir),
     opencodeSessionsDir: cleanPath(settings.opencodeSessionsDir),
     geminiSessionsDir: cleanPath(settings.geminiSessionsDir),
     hermesSessionsDir: cleanPath(settings.hermesSessionsDir),
@@ -556,7 +567,12 @@ function normalizeTotalDisplayUnit(value: unknown): Settings["totalDisplayUnit"]
 function normalizeEnabledSourceIds(value: unknown): string[] {
   if (!Array.isArray(value)) return [...STAT_SOURCE_IDS];
   const allowed = new Set<string>(STAT_SOURCE_IDS);
-  return [...new Set(value.filter((item): item is string => typeof item === "string" && allowed.has(item)))];
+  const normalized = [...new Set(value.filter((item): item is string => typeof item === "string" && allowed.has(item)))];
+  const hadAllLegacySources = ["codex", "openclaw", "opencode", "claude", "gemini", "hermes"].every((source) =>
+    normalized.includes(source),
+  );
+  if (hadAllLegacySources && !normalized.includes("pi")) normalized.splice(2, 0, "pi");
+  return normalized;
 }
 
 function cleanProxyUrl(value: unknown) {
@@ -1206,6 +1222,10 @@ function refreshTrayMenu() {
       enabled: false,
     },
     {
+      label: sourceStatusLabel("Pi Agent", piSessionStatus, "pi-session"),
+      enabled: false,
+    },
+    {
       label: sourceStatusLabel("OpenCode", opencodeSessionStatus, "opencode-session"),
       enabled: false,
     },
@@ -1335,6 +1355,7 @@ function xpForEntry(entry: LedgerEntry) {
 function statSourceIdForEntry(entry: LedgerEntry): string | undefined {
   if (entry.source === "codex-session" || entry.agent === "codex-desktop") return "codex";
   if (entry.source === "openclaw-session" || entry.agent === "openclaw") return "openclaw";
+  if (entry.source === "pi-session" || entry.agent === "pi-agent") return "pi";
   if (entry.source === "opencode-session" || entry.agent === "opencode" || Boolean(entry.agent?.startsWith("opencode:"))) {
     return "opencode";
   }
@@ -1425,6 +1446,7 @@ function updateSettings(partial: Partial<Settings>) {
     previous.codexSessionsDir !== ledger.settings.codexSessionsDir ||
     previous.claudeSessionsDir !== ledger.settings.claudeSessionsDir ||
     previous.openclawSessionsDir !== ledger.settings.openclawSessionsDir ||
+    previous.piSessionsDir !== ledger.settings.piSessionsDir ||
     previous.opencodeSessionsDir !== ledger.settings.opencodeSessionsDir ||
     previous.geminiSessionsDir !== ledger.settings.geminiSessionsDir ||
     previous.hermesSessionsDir !== ledger.settings.hermesSessionsDir
@@ -1471,6 +1493,7 @@ function getUsageStatus(): UsageStatus {
     codexSession: codexSessionStatus,
     claudeSession: claudeSessionStatus,
     openclawSession: openclawSessionStatus,
+    piSession: piSessionStatus,
     opencodeSession: opencodeSessionStatus,
     geminiSession: geminiSessionStatus,
     hermesSession: hermesSessionStatus,
@@ -2057,6 +2080,16 @@ function startUsageWatchers() {
       broadcast("bonsai:usage-status", getUsageStatus());
     },
   });
+  piSessionWatcher = startPiSessionWatcher({
+    ...common,
+    sessionsRoot: ledger.settings.piSessionsDir,
+    onUsage: appendUsageEvent,
+    onStatus: (status) => {
+      piSessionStatus = status;
+      refreshTrayMenu();
+      broadcast("bonsai:usage-status", getUsageStatus());
+    },
+  });
   opencodeSessionWatcher = startOpenCodeSessionWatcher({
     ...common,
     sessionsRoot: ledger.settings.opencodeSessionsDir,
@@ -2093,12 +2126,14 @@ function stopUsageWatchers() {
   codexSessionWatcher?.close();
   claudeSessionWatcher?.close();
   openclawSessionWatcher?.close();
+  piSessionWatcher?.close();
   opencodeSessionWatcher?.close();
   geminiSessionWatcher?.close();
   hermesSessionWatcher?.close();
   codexSessionWatcher = null;
   claudeSessionWatcher = null;
   openclawSessionWatcher = null;
+  piSessionWatcher = null;
   opencodeSessionWatcher = null;
   geminiSessionWatcher = null;
   hermesSessionWatcher = null;

--- a/src/renderer/achievements.ts
+++ b/src/renderer/achievements.ts
@@ -1,7 +1,7 @@
 import type { LedgerEntry } from "../shared/types";
 import type { AchievementCategory, AchievementRarity } from "./i18n";
 
-type HistorySourceId = "codex" | "openclaw" | "opencode" | "claude" | "gemini" | "hermes";
+type HistorySourceId = "codex" | "openclaw" | "pi" | "opencode" | "claude" | "gemini" | "hermes";
 
 interface AchievementStatsSnapshot {
   xp: number;
@@ -360,6 +360,15 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     condition: ({ activeSources }) => activeSources.has("openclaw"),
   },
   {
+    id: "pi_connected",
+    category: "agent",
+    rarity: "rare",
+    name: "Pi Agent 接入",
+    description: "Pi Agent 有第一条事件",
+    flavor: "新的分支长出来了。",
+    condition: ({ activeSources }) => activeSources.has("pi"),
+  },
+  {
     id: "opencode_connected",
     category: "agent",
     rarity: "rare",
@@ -391,9 +400,9 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: "agent",
     rarity: "legendary",
     name: "全家桶",
-    description: "六种 agent 全部接入",
+    description: "七种 agent 全部接入",
     flavor: "恭喜获得全家桶套餐，附赠加大可乐。",
-    condition: ({ activeSources }) => activeSources.size >= 6,
+    condition: ({ activeSources }) => activeSources.size >= 7,
   },
   {
     id: "multi_agent_day",

--- a/src/renderer/appShell.ts
+++ b/src/renderer/appShell.ts
@@ -378,6 +378,13 @@ export function appShellHtml(viewMode: ViewMode) {
               </div>
               <div class="agent-source-row">
                 <label class="agent-source-toggle">
+                  <input type="checkbox" data-stats-source="pi" />
+                  <span data-i18n="piPath">Pi Agent 路径</span>
+                </label>
+                <input id="piSessionsDirInput" type="text" placeholder="~/.pi/agent/sessions" aria-label="Pi Agent path" />
+              </div>
+              <div class="agent-source-row">
+                <label class="agent-source-toggle">
                   <input type="checkbox" data-stats-source="opencode" />
                   <span data-i18n="opencodePath">OpenCode 路径</span>
                 </label>

--- a/src/renderer/i18n.ts
+++ b/src/renderer/i18n.ts
@@ -224,9 +224,14 @@ export const ACHIEVEMENT_TEXT_EN: Record<string, AchievementCopy> = {
     description: "Hermes records its first event",
     flavor: "Message delivered. The tree noticed.",
   },
+  pi_connected: {
+    name: "Pi Agent Connected",
+    description: "Pi Agent records its first event",
+    flavor: "A new branch has joined the canopy.",
+  },
   all_agents: {
     name: "Full Agent Set",
-    description: "Connect all six agent sources",
+    description: "Connect all seven agent sources",
     flavor: "The whole squad is here.",
   },
   multi_agent_day: {
@@ -521,6 +526,7 @@ export const UI_TEXT: Record<AppLanguage, Record<string, string>> = {
     codexPath: "Codex 路径",
     claudePath: "Claude 路径",
     openclawPath: "OpenClaw 路径",
+    piPath: "Pi Agent 路径",
     opencodePath: "OpenCode 路径",
     geminiPath: "Gemini 路径",
     hermesPath: "Hermes 路径",
@@ -747,6 +753,7 @@ export const UI_TEXT: Record<AppLanguage, Record<string, string>> = {
     codexPath: "Codex Path",
     claudePath: "Claude Path",
     openclawPath: "OpenClaw Path",
+    piPath: "Pi Agent Path",
     opencodePath: "OpenCode Path",
     geminiPath: "Gemini Path",
     hermesPath: "Hermes Path",

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -309,6 +309,7 @@ const totalDisplayUnitSelect = document.querySelector<HTMLSelectElement>("#total
 const codexSessionsDirInput = document.querySelector<HTMLInputElement>("#codexSessionsDirInput");
 const claudeSessionsDirInput = document.querySelector<HTMLInputElement>("#claudeSessionsDirInput");
 const openclawSessionsDirInput = document.querySelector<HTMLInputElement>("#openclawSessionsDirInput");
+const piSessionsDirInput = document.querySelector<HTMLInputElement>("#piSessionsDirInput");
 const opencodeSessionsDirInput = document.querySelector<HTMLInputElement>("#opencodeSessionsDirInput");
 const geminiSessionsDirInput = document.querySelector<HTMLInputElement>("#geminiSessionsDirInput");
 const hermesSessionsDirInput = document.querySelector<HTMLInputElement>("#hermesSessionsDirInput");
@@ -357,6 +358,7 @@ function setupHistoryCard() {
         <button type="button" data-history-filter="all" data-i18n="all">全部</button>
         <button type="button" data-history-filter="codex">Codex</button>
         <button type="button" data-history-filter="openclaw">OpenClaw</button>
+        <button type="button" data-history-filter="pi">Pi Agent</button>
         <button type="button" data-history-filter="opencode">OpenCode</button>
         <button type="button" data-history-filter="claude">Claude Code</button>
         <button type="button" data-history-filter="gemini">Gemini</button>
@@ -1013,6 +1015,7 @@ function bindEvents() {
   openclawSessionsDirInput?.addEventListener("change", () =>
     updatePathSetting("openclawSessionsDir", openclawSessionsDirInput),
   );
+  piSessionsDirInput?.addEventListener("change", () => updatePathSetting("piSessionsDir", piSessionsDirInput));
   opencodeSessionsDirInput?.addEventListener("change", () =>
     updatePathSetting("opencodeSessionsDir", opencodeSessionsDirInput),
   );
@@ -1174,6 +1177,7 @@ async function updatePathSetting(
     | "codexSessionsDir"
     | "claudeSessionsDir"
     | "openclawSessionsDir"
+    | "piSessionsDir"
     | "opencodeSessionsDir"
     | "geminiSessionsDir"
     | "hermesSessionsDir",
@@ -2261,6 +2265,7 @@ function render() {
     syncInputValue(codexSessionsDirInput, ledger.settings.codexSessionsDir ?? "");
     syncInputValue(claudeSessionsDirInput, ledger.settings.claudeSessionsDir ?? "");
     syncInputValue(openclawSessionsDirInput, ledger.settings.openclawSessionsDir ?? "");
+    syncInputValue(piSessionsDirInput, ledger.settings.piSessionsDir ?? "");
     syncInputValue(opencodeSessionsDirInput, ledger.settings.opencodeSessionsDir ?? "");
     syncInputValue(geminiSessionsDirInput, ledger.settings.geminiSessionsDir ?? "");
     syncInputValue(hermesSessionsDirInput, ledger.settings.hermesSessionsDir ?? "");

--- a/src/renderer/sources.ts
+++ b/src/renderer/sources.ts
@@ -5,6 +5,7 @@ import type { AgentSource, HistorySourceId, SourceBreakdown, SourceVisibility } 
 export const AGENT_SOURCES = [
   { id: "codex", label: "Codex", statusKey: "codexSession" },
   { id: "openclaw", label: "OpenClaw", statusKey: "openclawSession" },
+  { id: "pi", label: "Pi Agent", statusKey: "piSession" },
   { id: "opencode", label: "OpenCode", statusKey: "opencodeSession" },
   { id: "claude", label: "Claude Code", statusKey: "claudeSession" },
   { id: "gemini", label: "Gemini", statusKey: "geminiSession" },
@@ -57,6 +58,7 @@ export function sourceVisibility(usageStatus: UsageStatus | null, enabledSourceI
 export function historySourceId(entry: LedgerEntry): HistorySourceId | undefined {
   if (entry.source === "codex-session" || entry.agent === "codex-desktop") return "codex";
   if (entry.source === "openclaw-session" || entry.agent === "openclaw") return "openclaw";
+  if (entry.source === "pi-session" || entry.agent === "pi-agent") return "pi";
   if (entry.source === "opencode-session" || entry.agent === "opencode" || Boolean(entry.agent?.startsWith("opencode:"))) {
     return "opencode";
   }
@@ -107,11 +109,13 @@ export function sourceMatchesBreakdownRow(row: SourceBreakdown, sourceId: Histor
     return row.id === "claude-code" || row.id === "claude-session" || row.label === "Claude Code" || row.id.startsWith("claude-code:");
   }
   if (sourceId === "openclaw") return row.id === "openclaw" || row.id === "openclaw-session" || row.label === "OpenClaw";
+  if (sourceId === "pi") return row.id === "pi-agent" || row.id === "pi-session" || row.label === "Pi Agent";
   if (sourceId === "opencode") {
     return row.id === "opencode" || row.id === "opencode-session" || row.label === "OpenCode" || row.id.startsWith("opencode:");
   }
   if (sourceId === "gemini") return row.id === "gemini" || row.id === "gemini-session" || row.label === "Gemini";
-  return row.id === "hermes" || row.id === "hermes-session" || row.label === "Hermes";
+  if (sourceId === "hermes") return row.id === "hermes" || row.id === "hermes-session" || row.label === "Hermes";
+  return false;
 }
 
 export function combineSourceRows(label: string, rows: SourceBreakdown[]): SourceBreakdown {
@@ -132,6 +136,7 @@ export function entryMatchesSourceKey(entry: LedgerEntry, sourceKey: string) {
   if (sourceKey === "codex") return entry.source === "codex-session" || entry.agent === "codex-desktop";
   if (sourceKey === "claude") return entry.source === "claude-session" || Boolean(entry.agent?.startsWith("claude-code"));
   if (sourceKey === "openclaw") return entry.source === "openclaw-session" || entry.agent === "openclaw";
+  if (sourceKey === "pi") return entry.source === "pi-session" || entry.agent === "pi-agent";
   if (sourceKey === "opencode") {
     return entry.source === "opencode-session" || entry.agent === "opencode" || Boolean(entry.agent?.startsWith("opencode:"));
   }
@@ -151,6 +156,7 @@ export function defaultSourceLabel(id: string, source: string, manualLabel: stri
   if (id === "claude-code" || source === "claude-session") return "Claude Code";
   if (id === "codex-desktop" || source === "codex-session") return "Codex";
   if (id === "openclaw" || source === "openclaw-session") return "OpenClaw";
+  if (id === "pi-agent" || source === "pi-session") return "Pi Agent";
   if (id.startsWith("opencode:")) return `OpenCode ${id.replace("opencode:", "")}`;
   if (id === "opencode" || source === "opencode-session") return "OpenCode";
   if (id === "gemini" || source === "gemini-session") return "Gemini";
@@ -159,7 +165,7 @@ export function defaultSourceLabel(id: string, source: string, manualLabel: stri
 }
 
 export function emptySourceTotals(): Record<HistorySourceId, number> {
-  return { codex: 0, openclaw: 0, opencode: 0, claude: 0, gemini: 0, hermes: 0 };
+  return { codex: 0, openclaw: 0, pi: 0, opencode: 0, claude: 0, gemini: 0, hermes: 0 };
 }
 
 export function safeTokens(value: number) {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2677,6 +2677,10 @@ label {
   background: #8ab4f8;
 }
 
+.history-tooltip-dot.pi {
+  background: #ff6b6b;
+}
+
 .history-tooltip-dot.hermes {
   background: #fbbc04;
 }
@@ -2704,6 +2708,11 @@ label {
 .legend-gemini,
 .history-segment.gemini {
   background: #8ab4f8;
+}
+
+.legend-pi,
+.history-segment.pi {
+  background: #ff6b6b;
 }
 
 .legend-hermes,

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -3,7 +3,7 @@ import type { AchievementCategory } from "./i18n";
 
 export type WeatherId = "clear" | "breeze" | "drizzle" | "rain" | "thunder" | "storm";
 export type ViewMode = "pet" | "manager" | "toast";
-export type HistorySourceId = "codex" | "openclaw" | "opencode" | "claude" | "gemini" | "hermes";
+export type HistorySourceId = "codex" | "openclaw" | "pi" | "opencode" | "claude" | "gemini" | "hermes";
 export type HistoryFilter = "all" | HistorySourceId;
 export type SourceScope = "today" | "total";
 export type BadgeMetric = "level" | "total" | "rate";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -103,6 +103,7 @@ export interface Settings {
   codexSessionsDir?: string;
   claudeSessionsDir?: string;
   openclawSessionsDir?: string;
+  piSessionsDir?: string;
   opencodeSessionsDir?: string;
   geminiSessionsDir?: string;
   hermesSessionsDir?: string;
@@ -169,6 +170,7 @@ export interface UsageStatus {
   codexSession: SessionMonitorStatus;
   claudeSession: SessionMonitorStatus;
   openclawSession: SessionMonitorStatus;
+  piSession: SessionMonitorStatus;
   opencodeSession: SessionMonitorStatus;
   geminiSession: SessionMonitorStatus;
   hermesSession: SessionMonitorStatus;


### PR DESCRIPTION
## Summary
- add a Pi Agent session watcher for ~/.pi/agent/sessions JSONL usage records
- wire Pi Agent into source settings, charts, source breakdowns, tray status, achievements, and leaderboard preferences
- document Pi Agent as a supported token source

## Verification
- npm run typecheck
- npm run build
- npm run smoke:electron