### PR TITLE
Prepare v0.7.2 stability release

### DIFF
--- a/docs/2026-06-03_RELEASE_V0.7.2.md
+++ b/docs/2026-06-03_RELEASE_V0.7.2.md
@@ -1,0 +1,63 @@
+# Vibe Tree v0.7.2 发布文案草案
+
+目标版本：`v0.7.2`。
+
+这是 `v0.7.1` 之后的补丁版，主要收口两个稳定性问题：macOS 菜单栏浮窗跨桌面显示，以及 Codex fork / 旧会话统计避免把历史重放误算成今日新增。
+
+## App 内更新公告
+
+当前 `updates/manifest.json` 中的短公告大致如下，发布前需要用户确认：
+
+```text
+Vibe Tree v0.7.2
+
+本次更新是一个稳定性补丁：macOS 菜单栏浮窗在切换桌面或全屏空间后更可靠，Codex fork 统计会以父会话累计 token 作为基线，只记录 fork 后真正新增的增量。升级不会清空本机小树；社交、排行榜和同养小树仍然都是可选功能。
+
+更新亮点
+- macOS 菜单栏浮窗现在可以跨桌面和全屏空间显示，点击状态栏小树时不应该再把你带回原来的桌面。
+- Codex fork 统计会继承父会话的累计 token 基线，避免把 fork 搬运过来的历史重放误算成新的今日成长。
+- fork 后继续产生的新 token 仍会按超过基线的增量正常记录。
+
+修复
+- 修复菜单栏浮窗切到其他桌面或全屏页面后可能不显示、或把系统切回原桌面的问题。
+- 修复 Codex fork 或旧会话重新打开时，历史重放可能被误算成今日新增 token 的问题。
+
+隐私
+- 本次更新没有新增上传字段。
+- Vibe Tree 仍然不会上传提示词、回复内容、代码文件、本地路径或会话正文。
+```
+
+## GitHub Release Notes
+
+```md
+# Vibe Tree v0.7.2
+
+## Fixed
+
+- Fixed the macOS menu bar popover so it can appear across Desktops and full-screen Spaces. Clicking the status item should no longer leave the popover behind on another Desktop or switch macOS back to the Desktop where it was first created.
+- Fixed Codex usage tracking for forked and old session files. Forked sessions now inherit the parent session's cumulative token baseline, so replayed history is not counted as fresh growth.
+- Kept post-fork work recording normally by counting only usage beyond the inherited baseline.
+
+## Privacy
+
+- No new uploaded fields were added in this release.
+- Vibe Tree still does not upload prompts, replies, code files, local paths, or session text.
+
+## Compatibility
+
+- Upgrading from v0.7.1 preserves local data.
+- No Worker or D1 migration is required for this patch.
+```
+
+## 发布前检查
+
+- `package.json` 和 `package-lock.json` 版本号更新到 `0.7.2`。
+- `updates/manifest.json` 增加 `0.7.2`，`fullReleaseUrl` 指向 `v0.7.2`。
+- `npm run typecheck`
+- `npm run build`
+- `npm run test:codex-watcher`
+- `npm run smoke:electron`
+- `npm run verify:cloud-sync`
+- `npm run verify:worker-api`
+- `git diff --check`
+- Mac 真机确认菜单栏浮窗在切换桌面或全屏空间后仍能打开。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-tree",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-tree",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "html-to-image": "^1.11.13",
         "qrcode": "^1.5.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-tree",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "productName": "Vibe Tree",
   "private": true,
   "type": "module",
@@ -11,6 +11,7 @@
     "build": "tsc -p tsconfig.electron.json && node scripts/copy-preload.mjs && vite build",
     "edit:achievements": "node scripts/achievement-copy-editor.mjs",
     "smoke:electron": "node scripts/smoke-electron.mjs",
+    "test:codex-watcher": "npm run build && node scripts/test-codex-session-watcher.mjs",
     "verify:cloud-sync": "node scripts/verify-cloud-sync.mjs",
     "verify:worker-api": "node server/leaderboard-worker/scripts/verify-worker-api.mjs",
     "typecheck": "tsc -p tsconfig.electron.json --noEmit && tsc -p tsconfig.json --noEmit",

--- a/scripts/test-codex-session-watcher.mjs
+++ b/scripts/test-codex-session-watcher.mjs
@@ -1,0 +1,201 @@
+import { appendFileSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { __test } from "../dist/electron/codexSessionWatcher.js";
+
+const { scanFile } = __test;
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function writeJsonl(filePath, lines) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
+}
+
+function appendJsonl(filePath, lines) {
+  appendFileSync(filePath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
+}
+
+function meta(timestamp, payload = {}) {
+  return { timestamp, type: "session_meta", payload };
+}
+
+function token(timestamp, total, last = total) {
+  return {
+    timestamp,
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: {
+        last_token_usage: {
+          input_tokens: last,
+          output_tokens: 0,
+          total_tokens: last,
+        },
+        total_token_usage: {
+          input_tokens: total,
+          output_tokens: 0,
+          total_tokens: total,
+        },
+      },
+    },
+  };
+}
+
+function newState() {
+  return {
+    version: 6,
+    files: {},
+    cumulativeTokens: {},
+    acceptedCumulativeKeys: {},
+    currentModels: {},
+  };
+}
+
+function runScan(filePath, state, statePath, sessionsRoot) {
+  const events = [];
+  const imported = scanFile(
+    filePath,
+    state,
+    statePath,
+    {
+      userDataPath: join(sessionsRoot, "..", "user-data"),
+      sessionsRoot,
+      onUsage: (event) => events.push(event),
+    },
+    {
+      importHistory: false,
+      watcherStartedAt: Date.parse("2026-06-04T00:00:00.000Z"),
+      sessionsRoot,
+    },
+  );
+  return { imported, events };
+}
+
+function makeSessionPath(root, date, id) {
+  const [year, month, day] = date.split("-");
+  return join(root, year, month, day, `rollout-${date}T00-00-00-${id}.jsonl`);
+}
+
+function runKnownParentForkTest(root) {
+  const sessionsRoot = join(root, "sessions-known-parent");
+  const statePath = join(root, "known-parent-state.json");
+  const parentId = "019e72e7-8395-7572-b6b8-8f480d6909bb";
+  const childId = "019f0000-0000-7000-8000-000000000001";
+  const parentPath = makeSessionPath(sessionsRoot, "2026-05-29", parentId);
+  const childPath = makeSessionPath(sessionsRoot, "2026-06-04", childId);
+  const state = newState();
+
+  writeJsonl(parentPath, [
+    meta("2026-05-29T16:00:00.000Z"),
+    token("2026-05-29T16:01:00.000Z", 100, 100),
+    token("2026-05-29T16:02:00.000Z", 200, 100),
+  ]);
+  writeJsonl(childPath, [
+    meta("2026-06-04T14:15:09.000Z", { forked_from_id: parentId }),
+    token("2026-06-04T14:15:09.100Z", 50, 50),
+    token("2026-06-04T14:15:09.200Z", 200, 150),
+    token("2026-06-04T14:20:00.000Z", 260, 60),
+  ]);
+
+  const { imported, events } = runScan(childPath, state, statePath, sessionsRoot);
+  assert(imported === 1, `known parent fork should import 1 event, got ${imported}`);
+  assert(events[0]?.totalTokens === 60, `known parent fork should import 60 tokens, got ${events[0]?.totalTokens}`);
+}
+
+function runHalfWrittenForkTest(root) {
+  const sessionsRoot = join(root, "sessions-half-written");
+  const statePath = join(root, "half-written-state.json");
+  const parentId = "019e72e7-8395-7572-b6b8-8f480d6909bc";
+  const childId = "019f0000-0000-7000-8000-000000000002";
+  const parentPath = makeSessionPath(sessionsRoot, "2026-05-29", parentId);
+  const childPath = makeSessionPath(sessionsRoot, "2026-06-04", childId);
+  const state = newState();
+
+  writeJsonl(parentPath, [
+    meta("2026-05-29T16:00:00.000Z"),
+    token("2026-05-29T16:01:00.000Z", 500, 500),
+    token("2026-05-29T16:02:00.000Z", 1000, 500),
+  ]);
+  writeJsonl(childPath, [
+    meta("2026-06-04T14:15:09.000Z", { forked_from_id: parentId }),
+    token("2026-06-04T14:15:09.100Z", 100, 100),
+    token("2026-06-04T14:15:09.200Z", 500, 400),
+  ]);
+
+  const first = runScan(childPath, state, statePath, sessionsRoot);
+  assert(first.imported === 0, `half-written replay first scan should import 0, got ${first.imported}`);
+
+  appendJsonl(childPath, [
+    token("2026-06-04T14:15:09.300Z", 1000, 500),
+    token("2026-06-04T14:20:00.000Z", 1150, 150),
+  ]);
+  const second = runScan(childPath, state, statePath, sessionsRoot);
+  assert(second.imported === 1, `half-written replay second scan should import 1, got ${second.imported}`);
+  assert(second.events[0]?.totalTokens === 150, `half-written replay should import 150 tokens, got ${second.events[0]?.totalTokens}`);
+}
+
+function runMissingParentForkTest(root) {
+  const sessionsRoot = join(root, "sessions-missing-parent");
+  const statePath = join(root, "missing-parent-state.json");
+  const missingParentId = "019e72e7-8395-7572-b6b8-8f480d6909bd";
+  const childId = "019f0000-0000-7000-8000-000000000003";
+  const childPath = makeSessionPath(sessionsRoot, "2026-06-04", childId);
+  const state = newState();
+
+  writeJsonl(childPath, [
+    meta("2026-06-04T14:15:09.000Z", { forked_from_id: missingParentId }),
+    token("2026-06-04T14:15:09.100Z", 50, 50),
+    token("2026-06-04T14:15:09.200Z", 200, 150),
+  ]);
+
+  const first = runScan(childPath, state, statePath, sessionsRoot);
+  assert(first.imported === 0, `missing parent fork should conservatively import 0, got ${first.imported}`);
+
+  appendJsonl(childPath, [token("2026-06-04T14:20:00.000Z", 260, 60)]);
+  const second = runScan(childPath, state, statePath, sessionsRoot);
+  assert(second.imported === 0, `missing parent first live append should establish baseline, got ${second.imported}`);
+
+  appendJsonl(childPath, [token("2026-06-04T14:21:00.000Z", 320, 60)]);
+  const third = runScan(childPath, state, statePath, sessionsRoot);
+  assert(third.imported === 1, `missing parent second live append should import 1, got ${third.imported}`);
+  assert(third.events[0]?.totalTokens === 60, `missing parent second live append should import 60, got ${third.events[0]?.totalTokens}`);
+}
+
+function runParentTailBaselineTest(root) {
+  const sessionsRoot = join(root, "sessions-parent-tail");
+  const statePath = join(root, "parent-tail-state.json");
+  const parentId = "019e72e7-8395-7572-b6b8-8f480d6909be";
+  const childId = "019f0000-0000-7000-8000-000000000004";
+  const parentPath = makeSessionPath(sessionsRoot, "2026-05-29", parentId);
+  const childPath = makeSessionPath(sessionsRoot, "2026-06-04", childId);
+  const state = newState();
+
+  writeJsonl(parentPath, [meta("2026-05-29T16:00:00.000Z")]);
+  appendFileSync(parentPath, `${JSON.stringify({ timestamp: "2026-05-29T16:00:30.000Z", type: "event_msg", payload: { type: "note", text: "x".repeat(512 * 1024) } })}\n`, "utf8");
+  appendJsonl(parentPath, [token("2026-05-29T16:02:00.000Z", 900, 900)]);
+  writeJsonl(childPath, [
+    meta("2026-06-04T14:15:09.000Z", { forked_from_id: parentId }),
+    token("2026-06-04T14:15:09.100Z", 100, 100),
+    token("2026-06-04T14:20:00.000Z", 950, 50),
+  ]);
+
+  const { imported, events } = runScan(childPath, state, statePath, sessionsRoot);
+  assert(imported === 1, `parent tail baseline should import 1 event, got ${imported}`);
+  assert(events[0]?.totalTokens === 50, `parent tail baseline should import 50 tokens, got ${events[0]?.totalTokens}`);
+}
+
+const root = mkdtempSync(join(tmpdir(), "vibe-tree-codex-watcher-"));
+try {
+  runKnownParentForkTest(root);
+  runHalfWrittenForkTest(root);
+  runMissingParentForkTest(root);
+  runParentTailBaselineTest(root);
+  console.log("codex session watcher fork tests passed");
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/src/electron/codexSessionWatcher.ts
+++ b/src/electron/codexSessionWatcher.ts
@@ -59,6 +59,9 @@ const POLL_INTERVAL_MS = 10_000;
 const READ_CHUNK_SIZE = 64 * 1024;
 const DEFAULT_SESSIONS_ROOT = join(homedir(), ".codex", "sessions");
 const WATCH_STATE_VERSION = 6;
+const SESSION_META_READ_LIMIT = 2 * 1024 * 1024;
+const PARENT_CUMULATIVE_TAIL_READ_LIMIT = 16 * 1024 * 1024;
+const PARENT_CUMULATIVE_TAIL_CHUNK_SIZE = 256 * 1024;
 
 export function startCodexSessionWatcher(options: CodexSessionWatcherOptions) {
   const sessionsRoot = options.sessionsRoot || process.env.VIBE_CODEX_SESSIONS_DIR || DEFAULT_SESSIONS_ROOT;
@@ -102,6 +105,7 @@ export function startCodexSessionWatcher(options: CodexSessionWatcherOptions) {
         importHistory,
         watcherStartedAt,
         historyStartAtMs,
+        sessionsRoot,
       });
       if (imported > 0) {
         status.eventsImported += imported;
@@ -131,17 +135,24 @@ function scanFile(
   state: WatchState,
   statePath: string,
   options: CodexSessionWatcherOptions,
-  settings: { importHistory: boolean; watcherStartedAt: number; historyStartAtMs?: number },
+  settings: { importHistory: boolean; watcherStartedAt: number; historyStartAtMs?: number; sessionsRoot: string },
 ): number {
   let imported = 0;
   const stats = statSync(filePath);
   const previousOffset = state.files[filePath];
+  if ((previousOffset === undefined || stats.size > previousOffset) && isArchivedCodexSession(filePath)) {
+    state.files[filePath] = stats.size;
+    writeState(statePath, state);
+    return imported;
+  }
+  const forkBaseline = seedForkCumulativeBaseline(filePath, state, settings.sessionsRoot);
   const offset =
     previousOffset ??
     initialOffset(filePath, stats, {
       importHistory: settings.importHistory,
       watcherStartedAt: settings.watcherStartedAt,
       historyStartAtMs: settings.historyStartAtMs,
+      hasForkBaseline: Boolean(forkBaseline),
     });
 
   if (stats.size <= offset) {
@@ -250,18 +261,173 @@ function scanNewLines(filePath: string, start: number, end: number, onLine: (lin
 function initialOffset(
   filePath: string,
   stats: Stats,
-  settings: { importHistory: boolean; watcherStartedAt: number; historyStartAtMs?: number },
+  settings: { importHistory: boolean; watcherStartedAt: number; historyStartAtMs?: number; hasForkBaseline?: boolean },
 ) {
+  if (settings.hasForkBaseline) {
+    return 0;
+  }
+  if (shouldBaselineInitialCodexSession(filePath)) {
+    return stats.size;
+  }
   if (settings.historyStartAtMs && stats.mtimeMs >= settings.historyStartAtMs - 5_000) {
     return 0;
   }
   if (settings.importHistory && isTodaySessionPath(filePath)) {
     return 0;
   }
-  if (stats.mtimeMs >= settings.watcherStartedAt - 5_000) {
+  if (stats.mtimeMs >= settings.watcherStartedAt - 5_000 && shouldImportRecentlyUpdatedSession(filePath)) {
     return 0;
   }
   return stats.size;
+}
+
+function shouldImportRecentlyUpdatedSession(filePath: string) {
+  const sessionDate = sessionPathDateKey(filePath);
+  return !sessionDate || sessionDate === todayDateKey();
+}
+
+function shouldBaselineInitialCodexSession(filePath: string) {
+  if (isArchivedCodexSession(filePath)) return true;
+  if (isForkedCodexSession(filePath)) return true;
+  const sessionDate = sessionPathDateKey(filePath);
+  return Boolean(sessionDate && sessionDate !== todayDateKey());
+}
+
+function isArchivedCodexSession(filePath: string) {
+  return /[\\/]archived_sessions[\\/]/.test(filePath);
+}
+
+function isForkedCodexSession(filePath: string) {
+  return Boolean(readCodexSessionMeta(filePath)?.forkedFromId);
+}
+
+function readCodexSessionMeta(filePath: string) {
+  const firstLine = readFirstLine(filePath, SESSION_META_READ_LIMIT);
+  if (!firstLine) return undefined;
+  const parsed = parseJson(firstLine);
+  if (parsed?.type !== "session_meta") return undefined;
+  const payload = asRecord(parsed?.payload);
+  return {
+    createdAtMs: typeof parsed.timestamp === "string" ? timestampMs(parsed.timestamp) : undefined,
+    forkedFromId: typeof payload?.forked_from_id === "string" ? payload.forked_from_id : undefined,
+  };
+}
+
+function seedForkCumulativeBaseline(filePath: string, state: WatchState, sessionsRoot: string | undefined) {
+  const meta = readCodexSessionMeta(filePath);
+  if (!meta?.forkedFromId || !sessionsRoot) return undefined;
+  const cumulativeKey = `${filePath}:total`;
+  const existingUsage = normalizeStoredUsage(state.cumulativeTokens[cumulativeKey]);
+  if (state.acceptedCumulativeKeys[cumulativeKey] && existingUsage) {
+    return existingUsage;
+  }
+
+  const baselineUsage = resolveForkParentCumulativeUsage(meta.forkedFromId, sessionsRoot, state, meta.createdAtMs);
+  if (!baselineUsage) return undefined;
+
+  const nextBaseline = maxUsage(baselineUsage, existingUsage);
+  state.cumulativeTokens[cumulativeKey] = nextBaseline;
+  state.acceptedCumulativeKeys[cumulativeKey] = true;
+  return nextBaseline;
+}
+
+function resolveForkParentCumulativeUsage(
+  parentSessionId: string,
+  sessionsRoot: string,
+  state: WatchState,
+  latestAtMs: number | undefined,
+) {
+  const parentFilePath = findCodexSessionFileById(parentSessionId, sessionsRoot, state);
+  if (!parentFilePath) return undefined;
+
+  const fileUsage = readLatestCumulativeUsageFromFile(parentFilePath, latestAtMs);
+  if (fileUsage) return fileUsage;
+  return normalizeStoredUsage(state.cumulativeTokens[`${parentFilePath}:total`]);
+}
+
+function findCodexSessionFileById(parentSessionId: string, sessionsRoot: string, state: WatchState) {
+  for (const key of Object.keys(state.cumulativeTokens)) {
+    if (key.endsWith(":total") && key.includes(parentSessionId)) {
+      return key.slice(0, -":total".length);
+    }
+  }
+  if (!existsSync(sessionsRoot)) return undefined;
+  return listJsonlFiles(sessionsRoot).find((candidate) => candidate.includes(parentSessionId));
+}
+
+function readLatestCumulativeUsageFromFile(filePath: string, latestAtMs: number | undefined) {
+  if (!existsSync(filePath)) return undefined;
+  const stats = statSync(filePath);
+  const fd = openSync(filePath, "r");
+  const maxBytes = Math.min(stats.size, PARENT_CUMULATIVE_TAIL_READ_LIMIT);
+  const buffer = Buffer.allocUnsafe(Math.min(PARENT_CUMULATIVE_TAIL_CHUNK_SIZE, maxBytes || 1));
+  let remaining = maxBytes;
+  let position = stats.size;
+  let carry = Buffer.alloc(0);
+
+  try {
+    while (remaining > 0) {
+      const bytesToRead = Math.min(buffer.length, remaining);
+      position -= bytesToRead;
+      remaining -= bytesToRead;
+      const bytesRead = readSync(fd, buffer, 0, bytesToRead, position);
+      if (bytesRead <= 0) break;
+      const data = Buffer.concat([buffer.subarray(0, bytesRead), carry]);
+      let lineEnd = data.length;
+      for (let index = data.length - 1; index >= 0; index -= 1) {
+        if (data[index] !== 10) continue;
+        const line = data.subarray(index + 1, lineEnd).toString("utf8").trim();
+        const usage = cumulativeUsageFromParentLine(line, filePath, latestAtMs);
+        if (usage) return usage;
+        lineEnd = index;
+      }
+      carry = data.subarray(0, lineEnd);
+    }
+
+    const line = carry.toString("utf8").trim();
+    return cumulativeUsageFromParentLine(line, filePath, latestAtMs);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function cumulativeUsageFromParentLine(line: string, filePath: string, latestAtMs: number | undefined) {
+  if (!line || !line.includes("\"token_count\"")) return undefined;
+  const event = parseCodexTokenCountLine(line, filePath, 0, undefined);
+  if (!event?.cumulativeUsage) return undefined;
+  const eventMs = timestampMs(event.createdAt);
+  if (latestAtMs && eventMs && eventMs > latestAtMs) return undefined;
+  return event.cumulativeUsage;
+}
+
+function readFirstLine(filePath: string, maxBytes: number) {
+  let fd: number | undefined;
+  const buffer = Buffer.allocUnsafe(Math.min(READ_CHUNK_SIZE, maxBytes));
+  const decoder = new StringDecoder("utf8");
+  let position = 0;
+  let pending = "";
+
+  try {
+    fd = openSync(filePath, "r");
+    while (position < maxBytes) {
+      const bytesToRead = Math.min(buffer.length, maxBytes - position);
+      const bytesRead = readSync(fd, buffer, 0, bytesToRead, position);
+      if (bytesRead <= 0) break;
+      position += bytesRead;
+      pending += decoder.write(buffer.subarray(0, bytesRead));
+      const newlineIndex = pending.indexOf("\n");
+      if (newlineIndex >= 0) {
+        const rawLine = pending.slice(0, newlineIndex);
+        return rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+      }
+    }
+    pending += decoder.end();
+    return pending.trim() ? pending : undefined;
+  } catch {
+    return undefined;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
 }
 
 function parseCodexTurnContextLine(line: string) {
@@ -497,16 +663,31 @@ function hash(value: string) {
   return createHash("sha256").update(value).digest("hex").slice(0, 24);
 }
 
+export const __test = {
+  scanFile,
+  readState,
+  writeState,
+};
+
 function isTodaySessionPath(filePath: string) {
+  return sessionPathDateKey(filePath) === todayDateKey();
+}
+
+function todayDateKey() {
   const now = new Date();
+  return [
+    String(now.getFullYear()),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+function sessionPathDateKey(filePath: string) {
   const parts = filePath.split(/[\\/]+/);
-  const year = String(now.getFullYear());
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
   for (let index = 0; index < parts.length - 2; index += 1) {
-    if (parts[index] === year && parts[index + 1] === month && parts[index + 2] === day) {
-      return true;
+    if (/^\d{4}$/.test(parts[index]) && /^\d{2}$/.test(parts[index + 1]) && /^\d{2}$/.test(parts[index + 2])) {
+      return `${parts[index]}-${parts[index + 1]}-${parts[index + 2]}`;
     }
   }
-  return false;
+  return undefined;
 }

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -968,6 +968,7 @@ function createMenuBarWindow() {
       sandbox: false,
     },
   });
+  applyMenuBarWindowSpaceBehavior(menuBarWindow);
   menuBarWindow.webContents.setZoomFactor(1);
   menuBarWindow.webContents.on("zoom-changed", (event) => event.preventDefault());
   void menuBarWindow.webContents.setVisualZoomLevelLimits(1, 1);
@@ -1275,6 +1276,7 @@ function toggleMenuBarPopover() {
     window.hide();
     return;
   }
+  applyMenuBarWindowSpaceBehavior(window);
   positionMenuBarWindow(window);
   window.show();
   window.focus();
@@ -1283,6 +1285,11 @@ function toggleMenuBarPopover() {
 function hideMenuBarPopover() {
   if (!menuBarWindow || menuBarWindow.isDestroyed()) return;
   menuBarWindow.hide();
+}
+
+function applyMenuBarWindowSpaceBehavior(window: BrowserWindow) {
+  window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+  window.setAlwaysOnTop(true, "pop-up-menu");
 }
 
 function positionMenuBarWindow(window: BrowserWindow) {

--- a/updates/manifest.json
+++ b/updates/manifest.json
@@ -2,6 +2,61 @@
   "schemaVersion": 1,
   "versions": [
     {
+      "version": "0.7.2",
+      "publishedAt": "2026-06-04",
+      "fullReleaseUrl": "https://github.com/Olorinm/vibe-tree/releases/tag/v0.7.2",
+      "title": {
+        "zh-CN": "Vibe Tree v0.7.2",
+        "en-US": "Vibe Tree v0.7.2"
+      },
+      "summary": {
+        "zh-CN": "本次更新是一个稳定性补丁：macOS 菜单栏浮窗在切换桌面或全屏空间后更可靠，Codex fork 统计会以父会话累计 token 作为基线，只记录 fork 后真正新增的增量。升级不会清空本机小树；社交、排行榜和同养小树仍然都是可选功能。",
+        "en-US": "This is a stability patch: the macOS menu bar popover behaves more reliably across Desktops and full-screen Spaces, and Codex fork tracking now uses the parent session's cumulative token total as a baseline so only real post-fork growth is recorded. Upgrading does not clear your local tree; social features, leaderboards, and shared-tree sync remain optional."
+      },
+      "highlights": {
+        "zh-CN": [
+          "macOS 菜单栏浮窗现在可以跨桌面和全屏空间显示，点击状态栏小树时不应该再把你带回原来的桌面。",
+          "Codex fork 统计会继承父会话的累计 token 基线，避免把 fork 搬运过来的历史重放误算成新的今日成长。",
+          "fork 后继续产生的新 token 仍会按超过基线的增量正常记录。"
+        ],
+        "en-US": [
+          "The macOS menu bar popover can now appear across Desktops and full-screen Spaces, so clicking the status item should no longer send you back to the original Desktop.",
+          "Codex fork tracking now inherits the parent session's cumulative token baseline so replayed history is not counted as new growth.",
+          "New tokens produced after the fork are still recorded as usage beyond that baseline."
+        ]
+      },
+      "fixes": {
+        "zh-CN": [
+          "修复菜单栏浮窗切到其他桌面或全屏页面后可能不显示、或把系统切回原桌面的问题。",
+          "修复 Codex fork 或旧会话重新打开时，历史重放可能被误算成今日新增 token 的问题。"
+        ],
+        "en-US": [
+          "Fixed the menu bar popover sometimes not appearing, or switching macOS back to the original Desktop, after moving to another Desktop or full-screen Space.",
+          "Fixed Codex usage tracking over-counting replayed history when forked or old sessions are reopened."
+        ]
+      },
+      "privacy": {
+        "zh-CN": [
+          "本次更新没有新增上传字段。",
+          "Vibe Tree 仍然不会上传提示词、回复内容、代码文件、本地路径或会话正文。"
+        ],
+        "en-US": [
+          "This update does not add any new uploaded fields.",
+          "Vibe Tree still does not upload prompts, replies, code files, local paths, or session text."
+        ]
+      },
+      "upgradeNotes": {
+        "zh-CN": [
+          "升级不会清空本机数据。",
+          "如果菜单栏小树仍然看不到，可能是系统菜单栏空间不足，可以先收起不常用的状态栏图标。"
+        ],
+        "en-US": [
+          "Upgrading does not clear local data.",
+          "If the menu bar tree is still not visible, the system menu bar may be out of space; hide less-used status items and try again."
+        ]
+      }
+    },
+    {
       "version": "0.7.1",
       "publishedAt": "2026-06-02",
       "fullReleaseUrl": "https://github.com/Olorinm/vibe-tree/releases/tag/v0.7.1",


### PR DESCRIPTION
## Summary
- prepare Vibe Tree v0.7.2 release metadata and in-app update manifest
- fix Codex fork usage tracking by seeding forked sessions from the parent cumulative token baseline
- keep menu bar popover visible across macOS Desktops and full-screen Spaces
- add a focused Codex watcher regression script for fork replay, half-written forks, missing parents, and tail-read parent baselines

## Validation
- npm run test:codex-watcher
- npm run typecheck
- npm run smoke:electron
- npm run verify:cloud-sync
- npm run verify:worker-api
- git diff --check
- updates/manifest.json JSON parse check

## Notes
- No new uploaded fields are added in this release.
- Untracked local preview HTML files are intentionally left out of this PR.