### PR TITLE
Stagger startup watcher scans

### DIFF
--- a/src/electron/agentSessionWatchers.ts
+++ b/src/electron/agentSessionWatchers.ts
@@ -104,6 +104,9 @@ const DEFAULT_OPENCODE_DB = defaultOpenCodeDbPath();
 const DEFAULT_OPENCODE_MESSAGES_ROOT = defaultOpenCodeMessagesRoot();
 const DEFAULT_GEMINI_ROOT = join(homedir(), ".gemini", "tmp");
 const DEFAULT_HERMES_STATE_DB = join(homedir(), ".hermes", "state.db");
+const INITIAL_SCAN_DELAY_MS = 2_500;
+const SCAN_BATCH_SIZE = 32;
+const SCAN_BATCH_DELAY_MS = 16;
 
 export function startClaudeSessionWatcher(options: SessionWatcherOptions) {
   return startAgentSessionWatcher(options, {
@@ -181,9 +184,29 @@ function startOpenCodeDbSessionWatcher(options: SessionWatcherOptions, dbPath: s
   };
 
   let closed = false;
+  let pollRunning = false;
+  let pollQueued = false;
+  let initialScanTimer: ReturnType<typeof setTimeout> | null = null;
 
-  const poll = () => {
+  const poll = async () => {
     if (closed) return;
+    if (pollRunning) {
+      pollQueued = true;
+      return;
+    }
+    pollRunning = true;
+    try {
+      do {
+        pollQueued = false;
+        runPoll();
+        if (pollQueued && !closed) await delay(SCAN_BATCH_DELAY_MS);
+      } while (pollQueued && !closed);
+    } finally {
+      pollRunning = false;
+    }
+  };
+
+  const runPoll = () => {
     status.exists = existsSync(dbPath);
     status.filesWatched = status.exists ? 1 : 0;
     status.lastScanAt = new Date().toISOString();
@@ -200,13 +223,14 @@ function startOpenCodeDbSessionWatcher(options: SessionWatcherOptions, dbPath: s
     options.onStatus?.(status);
   };
 
-  poll();
-  const timer = setInterval(poll, 10_000);
+  initialScanTimer = setTimeout(() => void poll(), INITIAL_SCAN_DELAY_MS);
+  const timer = setInterval(() => void poll(), 10_000);
 
   return {
     close: () => {
       closed = true;
       status.running = false;
+      if (initialScanTimer) clearTimeout(initialScanTimer);
       clearInterval(timer);
       writeState(statePath, state);
       options.onStatus?.(status);
@@ -252,9 +276,29 @@ export function startHermesSessionWatcher(options: SessionWatcherOptions) {
   };
 
   let closed = false;
+  let pollRunning = false;
+  let pollQueued = false;
+  let initialScanTimer: ReturnType<typeof setTimeout> | null = null;
 
-  const poll = () => {
+  const poll = async () => {
     if (closed) return;
+    if (pollRunning) {
+      pollQueued = true;
+      return;
+    }
+    pollRunning = true;
+    try {
+      do {
+        pollQueued = false;
+        runPoll();
+        if (pollQueued && !closed) await delay(SCAN_BATCH_DELAY_MS);
+      } while (pollQueued && !closed);
+    } finally {
+      pollRunning = false;
+    }
+  };
+
+  const runPoll = () => {
     status.exists = existsSync(stateDbPath);
     status.filesWatched = status.exists ? 1 : 0;
     status.lastScanAt = new Date().toISOString();
@@ -277,13 +321,14 @@ export function startHermesSessionWatcher(options: SessionWatcherOptions) {
     options.onStatus?.(status);
   };
 
-  poll();
-  const timer = setInterval(poll, 10_000);
+  initialScanTimer = setTimeout(() => void poll(), INITIAL_SCAN_DELAY_MS);
+  const timer = setInterval(() => void poll(), 10_000);
 
   return {
     close: () => {
       closed = true;
       status.running = false;
+      if (initialScanTimer) clearTimeout(initialScanTimer);
       clearInterval(timer);
       writeState(statePath, state);
       options.onStatus?.(status);
@@ -314,9 +359,28 @@ function startAgentSessionWatcher(options: SessionWatcherOptions, config: AgentC
   };
 
   let closed = false;
+  let pollRunning = false;
+  let pollQueued = false;
+  let initialScanTimer: ReturnType<typeof setTimeout> | null = null;
 
-  const poll = () => {
+  const poll = async () => {
     if (closed) return;
+    if (pollRunning) {
+      pollQueued = true;
+      return;
+    }
+    pollRunning = true;
+    try {
+      do {
+        pollQueued = false;
+        await runPoll();
+      } while (pollQueued && !closed);
+    } finally {
+      pollRunning = false;
+    }
+  };
+
+  const runPoll = async () => {
     status.exists = existsSync(config.sessionsRoot);
     status.lastScanAt = new Date().toISOString();
     if (!status.exists) {
@@ -326,11 +390,12 @@ function startAgentSessionWatcher(options: SessionWatcherOptions, config: AgentC
 
     const files = listJsonlFiles(config.sessionsRoot);
     status.filesWatched = files.length;
-    for (const filePath of files) {
+    options.onStatus?.(status);
+    for (let index = 0; index < files.length; index += 1) {
+      if (closed) return;
       const imported = scanFile(
-        filePath,
+        files[index],
         state,
-        statePath,
         config,
         { importHistory, watcherStartedAt, historyStartAtMs },
         options.onUsage,
@@ -339,17 +404,24 @@ function startAgentSessionWatcher(options: SessionWatcherOptions, config: AgentC
         status.eventsImported += imported;
         status.lastEventAt = new Date().toISOString();
       }
+      if ((index + 1) % SCAN_BATCH_SIZE === 0) {
+        writeState(statePath, state);
+        options.onStatus?.(status);
+        await delay(SCAN_BATCH_DELAY_MS);
+      }
     }
+    writeState(statePath, state);
     options.onStatus?.(status);
   };
 
-  poll();
-  const timer = setInterval(poll, config.pollIntervalMs);
+  initialScanTimer = setTimeout(() => void poll(), INITIAL_SCAN_DELAY_MS);
+  const timer = setInterval(() => void poll(), config.pollIntervalMs);
 
   return {
     close: () => {
       closed = true;
       status.running = false;
+      if (initialScanTimer) clearTimeout(initialScanTimer);
       clearInterval(timer);
       writeState(statePath, state);
       options.onStatus?.(status);
@@ -380,9 +452,28 @@ function startJsonAgentSessionWatcher(options: SessionWatcherOptions, config: Js
   };
 
   let closed = false;
+  let pollRunning = false;
+  let pollQueued = false;
+  let initialScanTimer: ReturnType<typeof setTimeout> | null = null;
 
-  const poll = () => {
+  const poll = async () => {
     if (closed) return;
+    if (pollRunning) {
+      pollQueued = true;
+      return;
+    }
+    pollRunning = true;
+    try {
+      do {
+        pollQueued = false;
+        await runPoll();
+      } while (pollQueued && !closed);
+    } finally {
+      pollRunning = false;
+    }
+  };
+
+  const runPoll = async () => {
     status.exists = existsSync(config.sessionsRoot);
     status.lastScanAt = new Date().toISOString();
     if (!status.exists) {
@@ -392,11 +483,12 @@ function startJsonAgentSessionWatcher(options: SessionWatcherOptions, config: Js
 
     const files = listJsonFiles(config.sessionsRoot, config.fileExtensions);
     status.filesWatched = files.length;
-    for (const filePath of files) {
+    options.onStatus?.(status);
+    for (let index = 0; index < files.length; index += 1) {
+      if (closed) return;
       const imported = scanJsonFile(
-        filePath,
+        files[index],
         state,
-        statePath,
         config,
         { importHistory, watcherStartedAt, historyStartAtMs },
         options.onUsage,
@@ -405,17 +497,24 @@ function startJsonAgentSessionWatcher(options: SessionWatcherOptions, config: Js
         status.eventsImported += imported;
         status.lastEventAt = new Date().toISOString();
       }
+      if ((index + 1) % SCAN_BATCH_SIZE === 0) {
+        writeState(statePath, state);
+        options.onStatus?.(status);
+        await delay(SCAN_BATCH_DELAY_MS);
+      }
     }
+    writeState(statePath, state);
     options.onStatus?.(status);
   };
 
-  poll();
-  const timer = setInterval(poll, config.pollIntervalMs);
+  initialScanTimer = setTimeout(() => void poll(), INITIAL_SCAN_DELAY_MS);
+  const timer = setInterval(() => void poll(), config.pollIntervalMs);
 
   return {
     close: () => {
       closed = true;
       status.running = false;
+      if (initialScanTimer) clearTimeout(initialScanTimer);
       clearInterval(timer);
       writeState(statePath, state);
       options.onStatus?.(status);
@@ -427,7 +526,6 @@ function startJsonAgentSessionWatcher(options: SessionWatcherOptions, config: Js
 function scanFile(
   filePath: string,
   state: WatchState,
-  statePath: string,
   config: AgentConfig,
   settings: { importHistory: boolean; watcherStartedAt: number; historyStartAtMs?: number },
   onUsage: (event: UsageEvent) => void,
@@ -451,14 +549,12 @@ function scanFile(
   });
 
   state.files[filePath] = stats.size;
-  writeState(statePath, state);
   return imported;
 }
 
 function scanJsonFile(
   filePath: string,
   state: WatchState,
-  statePath: string,
   config: JsonAgentConfig,
   settings: { importHistory: boolean; watcherStartedAt: number; historyStartAtMs?: number },
   onUsage: (event: UsageEvent) => void,
@@ -471,12 +567,10 @@ function scanJsonFile(
 
   if (previousMtime === undefined && shouldSkipInitialJsonFile(filePath, stats, settings)) {
     state.files[filePath] = stats.mtimeMs;
-    writeState(statePath, state);
     return 0;
   }
 
   state.files[filePath] = stats.mtimeMs;
-  writeState(statePath, state);
 
   const events = toUsageEvents(config.parseFile(filePath));
   let imported = 0;
@@ -491,7 +585,6 @@ function scanJsonFile(
     onUsage(event);
     imported += 1;
   }
-  if (imported > 0 || events.length > 0) writeState(statePath, state);
   return imported;
 }
 
@@ -725,6 +818,10 @@ function scanNewLines(filePath: string, start: number, end: number, onLine: (lin
   }
 
   return imported;
+}
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
 function parseClaudeLine(line: string, filePath: string, lineOffset: number): UsageEvent | undefined {

--- a/src/electron/codexSessionWatcher.ts
+++ b/src/electron/codexSessionWatcher.ts
@@ -63,6 +63,9 @@ const WATCH_STATE_VERSION = 6;
 const SESSION_META_READ_LIMIT = 2 * 1024 * 1024;
 const PARENT_CUMULATIVE_TAIL_READ_LIMIT = 16 * 1024 * 1024;
 const PARENT_CUMULATIVE_TAIL_CHUNK_SIZE = 256 * 1024;
+const INITIAL_SCAN_DELAY_MS = 2_500;
+const SCAN_BATCH_SIZE = 16;
+const SCAN_BATCH_DELAY_MS = 16;
 
 export function startCodexSessionWatcher(options: CodexSessionWatcherOptions) {
   const sessionsRoot = options.sessionsRoot || process.env.VIBE_CODEX_SESSIONS_DIR || DEFAULT_SESSIONS_ROOT;
@@ -90,61 +93,74 @@ export function startCodexSessionWatcher(options: CodexSessionWatcherOptions) {
   };
 
   let closed = false;
-  let polling = false;
+  let pollRunning = false;
+  let pollQueued = false;
+  let initialScanTimer: ReturnType<typeof setTimeout> | null = null;
 
   const poll = async () => {
-    if (closed || polling) return;
-    polling = true;
-    let nextYieldAt = Date.now() + SCAN_YIELD_INTERVAL_MS;
+    if (closed) return;
+    if (pollRunning) {
+      pollQueued = true;
+      return;
+    }
+    pollRunning = true;
     try {
-      status.exists = existsSync(sessionsRoot);
-      status.lastScanAt = new Date().toISOString();
-      if (!status.exists) {
-        options.onStatus?.(status);
-        return;
-      }
-      const files = listJsonlFiles(sessionsRoot);
-      status.filesWatched = files.length;
-      for (const filePath of files) {
-        if (closed) return;
-        const imported = await scanFile(filePath, state, statePath, options, {
-          importHistory,
-          watcherStartedAt,
-          historyStartAtMs,
-          sessionsRoot,
-          shouldYield: () => Date.now() >= nextYieldAt,
-          onYield: async () => {
-            await yieldToEventLoop();
-            nextYieldAt = Date.now() + SCAN_YIELD_INTERVAL_MS;
-          },
-        });
-        if (imported > 0) {
-          status.eventsImported += imported;
-          status.lastEventAt = new Date().toISOString();
-        }
-        if (Date.now() >= nextYieldAt) {
-          await yieldToEventLoop();
-          nextYieldAt = Date.now() + SCAN_YIELD_INTERVAL_MS;
-        }
-      }
-      options.onStatus?.(status);
-    } catch (error) {
-      console.error("Codex session watcher scan failed", error);
-      options.onStatus?.(status);
+      do {
+        pollQueued = false;
+        await runPoll();
+      } while (pollQueued && !closed);
     } finally {
-      polling = false;
+      pollRunning = false;
     }
   };
 
-  void poll();
-  const timer = setInterval(() => {
-    void poll();
-  }, POLL_INTERVAL_MS);
+  const runPoll = async () => {
+    status.exists = existsSync(sessionsRoot);
+    status.lastScanAt = new Date().toISOString();
+    if (!status.exists) {
+      options.onStatus?.(status);
+      return;
+    }
+    const files = listJsonlFiles(sessionsRoot);
+    status.filesWatched = files.length;
+    options.onStatus?.(status);
+    let nextYieldAt = Date.now() + SCAN_YIELD_INTERVAL_MS;
+    for (let index = 0; index < files.length; index += 1) {
+      if (closed) return;
+      const imported = await scanFile(files[index], state, statePath, options, {
+        importHistory,
+        watcherStartedAt,
+        historyStartAtMs,
+        sessionsRoot,
+        shouldYield: () => Date.now() >= nextYieldAt,
+        onYield: async () => {
+          await yieldToEventLoop();
+          nextYieldAt = Date.now() + SCAN_YIELD_INTERVAL_MS;
+        },
+      });
+      if (imported > 0) {
+        status.eventsImported += imported;
+        status.lastEventAt = new Date().toISOString();
+      }
+      if ((index + 1) % SCAN_BATCH_SIZE === 0) {
+        writeState(statePath, state);
+        options.onStatus?.(status);
+        await delay(SCAN_BATCH_DELAY_MS);
+        nextYieldAt = Date.now() + SCAN_YIELD_INTERVAL_MS;
+      }
+    }
+    writeState(statePath, state);
+    options.onStatus?.(status);
+  };
+
+  initialScanTimer = setTimeout(() => void poll(), INITIAL_SCAN_DELAY_MS);
+  const timer = setInterval(() => void poll(), POLL_INTERVAL_MS);
 
   return {
     close: () => {
       closed = true;
       status.running = false;
+      if (initialScanTimer) clearTimeout(initialScanTimer);
       clearInterval(timer);
       writeState(statePath, state);
       options.onStatus?.(status);
@@ -156,7 +172,7 @@ export function startCodexSessionWatcher(options: CodexSessionWatcherOptions) {
 async function scanFile(
   filePath: string,
   state: WatchState,
-  statePath: string,
+  _statePath: string,
   options: CodexSessionWatcherOptions,
   settings: {
     importHistory: boolean;
@@ -172,7 +188,6 @@ async function scanFile(
   const previousOffset = state.files[filePath];
   if ((previousOffset === undefined || stats.size > previousOffset) && isArchivedCodexSession(filePath)) {
     state.files[filePath] = stats.size;
-    writeState(statePath, state);
     return imported;
   }
   const forkBaseline = seedForkCumulativeBaseline(filePath, state, settings.sessionsRoot);
@@ -249,7 +264,6 @@ async function scanFile(
 
   state.files[filePath] = stats.size;
   if (currentModel) state.currentModels[filePath] = currentModel;
-  writeState(statePath, state);
   return imported;
 }
 
@@ -301,6 +315,10 @@ async function scanNewLines(
   }
 
   return imported;
+}
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
 function yieldToEventLoop() {

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -165,6 +165,8 @@ let trayMenuReopenTimer: ReturnType<typeof setTimeout> | null = null;
 let ledgerBroadcastTimer: ReturnType<typeof setTimeout> | null = null;
 let ledger: LedgerFile = { entries: [], settings: DEFAULT_SETTINGS, installedAt: startOfLocalDayIso(new Date()) };
 let ledgerEntryIds = new Set<string>();
+let pendingUsageEntries: LedgerEntry[] = [];
+let pendingUsageFlushTimer: ReturnType<typeof setTimeout> | null = null;
 let achievementState: AchievementState = { unlocked: [] };
 let codexSessionWatcher: ReturnType<typeof startCodexSessionWatcher> | null = null;
 let claudeSessionWatcher: ReturnType<typeof startClaudeSessionWatcher> | null = null;
@@ -414,7 +416,7 @@ function setTreeStartMode(mode: "new" | "cloud") {
   ledger.entries = ledger.entries.filter((entry) =>
     mode === "cloud" ? entryBelongsToCurrentTree(entry, installedAt) : entryTime(entry) >= Date.parse(installedAt),
   );
-  rebuildLedgerEntryIndex();
+  resetLedgerEntryIds();
   updateSettings({ treeStartMode: mode });
 }
 
@@ -1821,6 +1823,29 @@ function cleanCloudModelLabel(value: unknown) {
   return typeof value === "string" && value.trim() ? value.trim().slice(0, 64) : undefined;
 }
 
+function resetLedgerEntryIds() {
+  ledgerEntryIds = new Set(ledger.entries.map((entry) => entry.id));
+}
+
+function schedulePendingUsageFlush() {
+  if (pendingUsageFlushTimer) return;
+  pendingUsageFlushTimer = setTimeout(flushPendingUsageEntries, 1_000);
+}
+
+function flushPendingUsageEntries() {
+  if (pendingUsageFlushTimer) {
+    clearTimeout(pendingUsageFlushTimer);
+    pendingUsageFlushTimer = null;
+  }
+  if (!pendingUsageEntries.length) return;
+
+  const entries = pendingUsageEntries;
+  pendingUsageEntries = [];
+  ledger.entries = entries.reverse().concat(ledger.entries);
+  scheduleLedgerBroadcast();
+  leaderboardService.scheduleCloudSyncSoon();
+}
+
 function appendUsageEvent(event: UsageEvent) {
   if (ledgerEntryIds.has(event.id)) return;
 
@@ -1840,14 +1865,14 @@ function appendUsageEvent(event: UsageEvent) {
     deviceId: ensureCloudSyncDeviceId(),
   };
   entry.tokens = countedTokensForEntry(entry);
-  ledger.entries.unshift(entry);
   ledgerEntryIds.add(entry.id);
+  pendingUsageEntries.push(entry);
   appendUsageEntryToStore(entry);
-  scheduleLedgerBroadcast();
-  leaderboardService.scheduleCloudSyncSoon();
+  schedulePendingUsageFlush();
 }
 
 function appendRemoteEntries(entries: LedgerEntry[]) {
+  flushPendingUsageEntries();
   const existingById = new Map(ledger.entries.map((entry) => [entry.id, entry]));
   const existingByFingerprint = new Map<string, LedgerEntry>();
   for (const entry of ledger.entries) {
@@ -1893,7 +1918,7 @@ function appendRemoteEntries(entries: LedgerEntry[]) {
     const deduped = dedupeCloudMirroredEntries(ledger.entries);
     if (!deduped.removedCount) return 0;
     ledger.entries = deduped.entries;
-    rebuildLedgerEntryIndex();
+    resetLedgerEntryIds();
     rewriteUsageEntriesStore(ledger.entries);
     broadcastLedgerNow();
     return deduped.removedCount;
@@ -1902,7 +1927,7 @@ function appendRemoteEntries(entries: LedgerEntry[]) {
   const kept = ledger.entries.filter((entry) => !repairedIds.has(entry.id));
   const deduped = dedupeCloudMirroredEntries([...accepted, ...repaired, ...kept]);
   ledger.entries = deduped.entries;
-  rebuildLedgerEntryIndex();
+  resetLedgerEntryIds();
   if (repaired.length || deduped.removedCount) rewriteUsageEntriesStore(ledger.entries);
   broadcastLedgerNow();
   return accepted.length + repaired.length + deduped.removedCount;
@@ -2144,10 +2169,6 @@ function broadcast(channel: string, ...args: unknown[]) {
     if (!window || window.isDestroyed()) continue;
     window.webContents.send(channel, ...args);
   }
-}
-
-function rebuildLedgerEntryIndex() {
-  ledgerEntryIds = new Set(ledger.entries.map((entry) => entry.id));
 }
 
 function broadcastLedgerNow() {
@@ -3000,7 +3021,7 @@ app.whenReady().then(async () => {
   }
   Menu.setApplicationMenu(null);
   ledger = readLedger();
-  rebuildLedgerEntryIndex();
+  resetLedgerEntryIds();
   updateStatus = {
     ...updateStatus,
     currentVersion: currentAppVersion(),
@@ -3014,7 +3035,7 @@ app.whenReady().then(async () => {
     createManagerWindow();
   }
   createTray();
-  setTimeout(startUsageWatchers, 500);
+  setTimeout(startUsageWatchers, 3_000);
   startUpdateChecks();
   leaderboardService.startSync();
 
@@ -3029,6 +3050,7 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", () => {
+  flushPendingUsageEntries();
   stopUsageWatchers();
   if (updateCheckTimer) clearTimeout(updateCheckTimer);
   if (ledgerBroadcastTimer) clearTimeout(ledgerBroadcastTimer);


### PR DESCRIPTION
## Summary
- Delay session watchers until after the first UI paint window.
- Process Codex/Claude and other session watcher scans in small async batches so startup does not block the app event loop.
- Batch imported usage events before broadcasting the full ledger, avoiding one full renderer recalculation per token event during catch-up.
- Keep usage-events.jsonl writes immediate so imported data is still durable even before the UI refresh batch flushes.

## Stress test
Simulated a long-unopened app with a temporary userData directory, 40k existing ledger rows, 80 Codex jsonl sessions, and 500 Claude jsonl sessions.

Before batching usage broadcasts, the synthetic run stayed around 440-480% total CPU for 75 seconds and only imported 544 new rows.

After batching, the same shape imported roughly 110k new rows by 15 seconds, dropped near idle by 20-30 seconds, and the watcher state files were written for all 80 Codex and 500 Claude files.

## Validation
- npm run typecheck
- npm run smoke:electron
- npm run test:codex-watcher
- git diff --check