### PR TITLE
Prepare v0.7.4 stability release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-06-18 (v0.7.4)
+
+- Delayed and batched startup session watcher scans so the app can paint before large local Codex, Claude, and other agent folders are backfilled.
+- Kept Codex fork/resume accounting on the parent cumulative-token baseline while adding file-level yielding and batched watcher state writes.
+- Batched imported usage entries before merging them into the in-memory ledger, reducing CPU spikes during large local backfills.
+
 ## 2026-06-18 (v0.7.3)
 
 - Made Codex session scanning yield in small slices so large local session folders do not monopolize the Electron main process during startup.

--- a/docs/2026-06-18_RELEASE_V0.7.4.md
+++ b/docs/2026-06-18_RELEASE_V0.7.4.md
@@ -1,0 +1,73 @@
+# Vibe Tree v0.7.4 发布文案草案
+
+目标版本：`v0.7.4`。
+
+这是 `v0.7.3` 之后的补丁版，继续修复长时间未打开后重新启动时的本地会话补扫卡顿，并保持 Codex 继续 / 复制旧会话时的统计口径正确。
+
+这份文档分成两部分：
+
+- App 内更新公告：来自 `updates/manifest.json`，给普通用户快速理解本次更新。
+- GitHub Release Notes：正常 release 记录，给想了解完整版本变化的用户和开发者看。
+
+## App 内更新公告
+
+App 内公告不直接展示完整 GitHub Release body，而是读取 `updates/manifest.json` 里对应版本的结构化内容。
+
+当前 `updates/manifest.json` 中的短公告大致如下：
+
+```text
+Vibe Tree v0.7.4
+
+本次更新继续优化启动稳定性：长时间未打开、累计大量 Codex 或 Claude 会话后，Vibe Tree 会延后并分批补扫本地 Token，减少打开时的卡顿；继续或复制旧 Codex 会话的统计口径也会保持正确。
+
+主要变化
+- 启动时会先让主界面出现，再延后扫描本地会话数据。
+- Codex、Claude 等本地会话会分批读取，避免一次性占满主进程。
+- 大量补扫的 Token 会合并刷新界面，减少短时间 CPU 峰值。
+- 继续或复制旧 Codex 会话时，旧历史不会算成新增；之后真正产生的新 Token 仍会正常计入。
+
+体验改进
+- 修复长时间未打开后重新启动，积累大量本地会话时可能卡顿很久的问题。
+- 修复 Claude 等非 Codex 来源在启动补扫时仍可能一次性同步扫完大量文件的问题。
+- 修复大量本地用量补扫时，内存数据逐条插入和逐条刷新带来的额外压力。
+```
+
+## GitHub Release Notes
+
+```md
+# Vibe Tree v0.7.4
+
+## Changed
+
+- Startup session watchers now wait briefly before scanning local agent folders, giving the app window a chance to render before catch-up work begins.
+- Codex, Claude, and other local session watchers now process files in batches and avoid overlapping poll cycles during large backfills.
+- Imported usage events are buffered before being merged into the in-memory ledger, so large local catch-ups do not rebuild the whole UI one event at a time.
+
+## Fixed
+
+- Fixed long startup stalls after Vibe Tree has been closed for a while and many local sessions have accumulated.
+- Fixed non-Codex local sources, such as Claude Code, still scanning large session folders synchronously during startup catch-up.
+- Preserved the v0.7.3 Codex fork/resume accounting fix while making large Codex session scans yield and checkpoint watcher state in batches.
+
+## Privacy
+
+- No uploaded content or uploaded fields were added in this release.
+
+## Compatibility
+
+- No Worker or D1 migration is required for this patch.
+- Existing local usage data and watcher state remain compatible with v0.7.3.
+```
+
+## 发布前检查
+
+- `package.json` 和 `package-lock.json` 版本号更新到 `0.7.4`。
+- `updates/manifest.json` 增加 `0.7.4`，`fullReleaseUrl` 指向 `v0.7.4`。
+- `npm run typecheck`
+- `npm run build`
+- `npm run test:codex-watcher`
+- `npm run smoke:electron`
+- `npm run verify:cloud-sync`
+- `npm run verify:worker-api`
+- `git diff --check`
+- 压力模拟：大量旧 ledger + Codex / Claude session 文件补扫完成后不再持续高 CPU。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-tree",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-tree",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "dependencies": {
         "html-to-image": "^1.11.13",
         "qrcode": "^1.5.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-tree",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "productName": "Vibe Tree",
   "private": true,
   "type": "module",

--- a/updates/manifest.json
+++ b/updates/manifest.json
@@ -2,6 +2,53 @@
   "schemaVersion": 1,
   "versions": [
     {
+      "version": "0.7.4",
+      "publishedAt": "2026-06-18",
+      "fullReleaseUrl": "https://github.com/open-grove/vibe-tree/releases/tag/v0.7.4",
+      "title": {
+        "zh-CN": "Vibe Tree v0.7.4",
+        "en-US": "Vibe Tree v0.7.4"
+      },
+      "summary": {
+        "zh-CN": "本次更新继续优化启动稳定性：长时间未打开、累计大量 Codex 或 Claude 会话后，Vibe Tree 会延后并分批补扫本地 Token，减少打开时的卡顿；继续或复制旧 Codex 会话的统计口径也会保持正确。",
+        "en-US": "This update further improves startup stability: after Vibe Tree has been closed for a while and many Codex or Claude sessions have accumulated, local token backfills now start later and run in batches, reducing startup stalls while keeping resumed or duplicated Codex sessions counted correctly."
+      },
+      "highlights": {
+        "zh-CN": [
+          "启动时会先让主界面出现，再延后扫描本地会话数据。",
+          "Codex、Claude 等本地会话会分批读取，避免一次性占满主进程。",
+          "大量补扫的 Token 会合并刷新界面，减少短时间 CPU 峰值。",
+          "继续或复制旧 Codex 会话时，旧历史不会算成新增；之后真正产生的新 Token 仍会正常计入。"
+        ],
+        "en-US": [
+          "The main window gets a chance to appear before local session scanning begins.",
+          "Codex, Claude, and other local session sources are scanned in batches instead of monopolizing the main process.",
+          "Large token backfills now refresh the UI in batches, reducing short CPU spikes.",
+          "Resumed or duplicated Codex sessions still ignore carried-over history while counting real new tokens afterward."
+        ]
+      },
+      "fixes": {
+        "zh-CN": [
+          "修复长时间未打开后重新启动，积累大量本地会话时可能卡顿很久的问题。",
+          "修复 Claude 等非 Codex 来源在启动补扫时仍可能一次性同步扫完大量文件的问题。",
+          "修复大量本地用量补扫时，内存数据逐条插入和逐条刷新带来的额外压力。"
+        ],
+        "en-US": [
+          "Fixed long startup stalls after many local sessions accumulate while Vibe Tree is closed.",
+          "Fixed non-Codex sources such as Claude still scanning many files synchronously during startup backfills.",
+          "Fixed extra pressure from inserting and refreshing large local usage backfills one entry at a time."
+        ]
+      },
+      "privacy": {
+        "zh-CN": [
+          "本次更新没有新增上传内容。"
+        ],
+        "en-US": [
+          "This update does not add any uploaded content."
+        ]
+      }
+    },
+    {
       "version": "0.7.3",
       "publishedAt": "2026-06-18",
       "fullReleaseUrl": "https://github.com/Olorinm/vibe-tree/releases/tag/v0.7.3",


### PR DESCRIPTION
## Summary
- Bump Vibe Tree to v0.7.4.
- Add the v0.7.4 in-app update manifest entry and release notes draft.
- Update CHANGELOG for the startup watcher stability patch.

## Verification
- npm run typecheck
- npm run build
- npm run smoke:electron
- npm run test:codex-watcher
- npm run verify:cloud-sync
- npm run verify:worker-api
- git diff --check