### PR TITLE
Release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-07-15 (v0.8.2)
+
+- Fixed the Vibe Tree menu bar item remaining invisible on macOS 26 even when it was enabled in System Settings, using a native AppKit status item while preserving the existing popover and context menu.
+
 ## 2026-07-15 (v0.8.1)
 
 - Made macOS command-line startup build and launch a local `Vibe Tree.app` with a stable menu bar and Dock identity while keeping existing local data.

--- a/docs/2026-07-15_RELEASE_V0.8.2.md
+++ b/docs/2026-07-15_RELEASE_V0.8.2.md
@@ -1,0 +1,56 @@
+# Vibe Tree v0.8.2 发布文案
+
+目标版本：`v0.8.2`。
+
+这是 `v0.8.1` 之后的补丁版本，修复部分新版 macOS 上菜单栏小树入口不可见的问题。
+
+## App 内更新公告
+
+### Vibe Tree v0.8.2
+
+修复部分新版 macOS 上，已经允许 Vibe Tree 显示在菜单栏，但小树入口仍然不可见的问题。
+
+- 菜单栏小树改用原生 macOS 状态项显示。
+- 点击小树仍会打开原来的成长浮窗，右键菜单保持不变。
+- 本次更新只调整本机菜单栏显示，不改变同步或上传内容。
+
+## GitHub Release Notes
+
+```md
+# Vibe Tree v0.8.2
+
+## Changed
+
+- On macOS 26 and later, Vibe Tree now uses a native AppKit status item for its menu bar entry.
+- Older macOS versions and Windows retain their existing behavior.
+
+## Fixed
+
+- Fixed the Vibe Tree menu bar icon remaining invisible even when the app was enabled under System Settings → Menu Bar.
+- The native status item keeps the existing popover and context-menu behavior and exits together with Vibe Tree.
+
+## Privacy
+
+- This release does not change synced or uploaded data.
+
+## Compatibility
+
+- No Worker or D1 migration is required.
+```
+
+## 发布前检查
+
+- `package.json` 和 `package-lock.json` 版本号为 `0.8.2`。
+- `updates/manifest.json` 首项为 `0.8.2`，发布链接指向 `v0.8.2`。
+- macOS 26 及以上使用原生菜单栏状态项，旧版 macOS 和 Windows 保持原行为。
+- 菜单栏小树可见，左键可打开成长浮窗，右键菜单保持可用。
+- `npm run typecheck`
+- `npm run build`
+- `npm run test:mac-start`
+- `npm run test:mac-handoff`
+- `npm run package:mac`
+- `npm run test:mac-package`
+- `npm run smoke:electron`
+- `npm run verify:cloud-sync`
+- `npm run verify:worker-api`
+- `git diff --check`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-tree",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-tree",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "html-to-image": "^1.11.13",
         "qrcode": "^1.5.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-tree",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "productName": "Vibe Tree",
   "private": true,
   "type": "module",

--- a/scripts/package-macos-app.mjs
+++ b/scripts/package-macos-app.mjs
@@ -21,6 +21,8 @@ const buildMarkerPath = join(resourcesDir, "vibe-tree-build.json");
 const iconSource = join(root, "public/assets/app-icon.png");
 const iconsetDir = join(root, "dist/.vibe-tree.iconset");
 const iconPath = join(resourcesDir, "vibe-tree.icns");
+const menuBarHelperSource = join(root, "src/native/macosMenuBarHelper.swift");
+const menuBarHelperPath = join(resourcesDir, "bin/vibe-tree-menu-bar-helper");
 const userDataDir = process.env.VIBE_TREE_PACKAGE_USER_DATA_DIR?.trim();
 const plistBuddy = "/usr/libexec/PlistBuddy";
 
@@ -28,6 +30,7 @@ if (!existsSync(sourceApp)) throw new Error(`Electron.app not found: ${sourceApp
 if (!existsSync(join(root, "dist/electron/main.js"))) throw new Error("Run npm run build before packaging.");
 if (!existsSync(metadataPath)) throw new Error("Compiled app metadata is missing. Run npm run build before packaging.");
 if (!existsSync(iconSource)) throw new Error(`App icon not found: ${iconSource}`);
+if (!existsSync(menuBarHelperSource)) throw new Error(`Menu bar helper source not found: ${menuBarHelperSource}`);
 
 const { APP_ID, APP_NAME } = await import(pathToFileURL(metadataPath).href);
 const legacyExecutablePath = join(outputApp, "Contents/MacOS/Electron");
@@ -46,6 +49,7 @@ const fingerprintPaths = [
   join(root, "dist/shared"),
   join(root, "package.json"),
   iconSource,
+  menuBarHelperSource,
   join(sourceApp, "Contents/Info.plist"),
   fileURLToPath(import.meta.url),
 ];
@@ -136,6 +140,13 @@ for (const [size, name] of iconSizes) {
 }
 execFileSync("/usr/bin/iconutil", ["-c", "icns", iconsetDir, "-o", iconPath]);
 rmSync(iconsetDir, { force: true, recursive: true });
+
+mkdirSync(join(resourcesDir, "bin"), { recursive: true });
+execFileSync(
+  "/usr/bin/xcrun",
+  ["swiftc", "-O", "-framework", "AppKit", menuBarHelperSource, "-o", menuBarHelperPath],
+  { stdio: "inherit" },
+);
 
 writeFileSync(
   buildMarkerPath,

--- a/scripts/test-macos-package.mjs
+++ b/scripts/test-macos-package.mjs
@@ -24,6 +24,8 @@ const projectPackage = JSON.parse(readFileSync(join(root, "package.json"), "utf8
 const appPackage = JSON.parse(readFileSync(join(resourcesDir, "app/package.json"), "utf8"));
 const buildMarker = JSON.parse(readFileSync(join(resourcesDir, "vibe-tree-build.json"), "utf8"));
 const packagedMetadata = readFileSync(join(resourcesDir, "app/shared/appMetadata.js"), "utf8");
+const menuBarHelperSource = join(root, "src/native/macosMenuBarHelper.swift");
+const menuBarHelperPath = join(resourcesDir, "bin/vibe-tree-menu-bar-helper");
 const plistBuddy = "/usr/libexec/PlistBuddy";
 const plistValue = (key) =>
   execFileSync(plistBuddy, ["-c", `Print :${key}`, plistPath], { encoding: "utf8" }).trim();
@@ -37,6 +39,13 @@ assert(existsSync(join(appPath, `Contents/MacOS/${metadata.APP_NAME}`)), "the na
 assert(appPackage.productName === metadata.APP_NAME, "the packaged Electron product name should match shared metadata");
 assert(buildMarker.appId === metadata.APP_ID && buildMarker.buildFingerprint, "the reusable build marker should be valid");
 assert(packagedMetadata.includes(metadata.MAC_TRAY_GUID), "the packaged app should contain the stable tray GUID");
+assert(existsSync(menuBarHelperPath), "the native macOS menu bar helper should be packaged");
+const menuBarHelperCheck = execFileSync(
+  menuBarHelperPath,
+  ["--check", join(resourcesDir, "app/renderer/assets/menu-bar-sprout.png")],
+  { encoding: "utf8" },
+);
+assert(menuBarHelperCheck.includes("helper check passed"), "the menu bar helper should load its packaged icon");
 execFileSync("/usr/bin/codesign", ["--verify", "--deep", "--strict", appPath], { stdio: "ignore" });
 
 const expectedFingerprint = computeMacBuildFingerprint({
@@ -48,6 +57,7 @@ const expectedFingerprint = computeMacBuildFingerprint({
     join(root, "dist/shared"),
     join(root, "package.json"),
     join(root, "public/assets/app-icon.png"),
+    menuBarHelperSource,
     join(sourceApp, "Contents/Info.plist"),
     packageScriptPath,
   ],

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -162,6 +162,10 @@ let updateStatus: UpdateStatus = {
 let tray: Tray | null = null;
 let trayContextMenu: ReturnType<typeof Menu.buildFromTemplate> | null = null;
 let trayMenuReopenTimer: ReturnType<typeof setTimeout> | null = null;
+let macMenuBarHelper: ReturnType<typeof spawn> | null = null;
+let macMenuBarHelperBuffer = "";
+let lastMacMenuBarPoint: Electron.Point | null = null;
+let isQuitting = false;
 let ledgerBroadcastTimer: ReturnType<typeof setTimeout> | null = null;
 let ledger: LedgerFile = { entries: [], settings: DEFAULT_SETTINGS, installedAt: startOfLocalDayIso(new Date()) };
 let ledgerEntryIds = new Set<string>();
@@ -1256,6 +1260,15 @@ function recoverPetWindow() {
 }
 
 function createTray() {
+  if (startMacMenuBarHelper()) {
+    refreshTrayMenu();
+    return;
+  }
+  createElectronTray();
+}
+
+function createElectronTray() {
+  if (tray) return;
   tray = new Tray(createTrayIcon(), process.platform === "darwin" ? MAC_TRAY_GUID : undefined);
   tray.setToolTip(APP_NAME);
   tray.on("click", toggleMenuBarPopover);
@@ -1264,6 +1277,76 @@ function createTray() {
     if (trayContextMenu) tray?.popUpContextMenu(trayContextMenu);
   });
   refreshTrayMenu();
+}
+
+function startMacMenuBarHelper() {
+  if (process.platform !== "darwin" || !app.isPackaged) return false;
+  const systemMajor = Number.parseInt(process.getSystemVersion().split(".")[0] ?? "0", 10);
+  if (!Number.isFinite(systemMajor) || systemMajor < 26) return false;
+
+  const helperPath = join(process.resourcesPath, "bin", "vibe-tree-menu-bar-helper");
+  const iconPath = MAC_MENU_BAR_ICON_PATHS.find((candidate) => existsSync(candidate));
+  if (!existsSync(helperPath) || !iconPath) return false;
+
+  const helper = spawn(helperPath, [iconPath, String(process.pid)], {
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  macMenuBarHelper = helper;
+  macMenuBarHelperBuffer = "";
+  helper.stdout.setEncoding("utf8");
+  helper.stdout.on("data", (chunk: string) => {
+    macMenuBarHelperBuffer += chunk;
+    const lines = macMenuBarHelperBuffer.split(/\r?\n/);
+    macMenuBarHelperBuffer = lines.pop() ?? "";
+    for (const line of lines) handleMacMenuBarHelperEvent(line.trim());
+  });
+  helper.once("error", (error) => {
+    if (macMenuBarHelper !== helper) return;
+    console.error("Failed to start the native macOS menu bar helper", error);
+    macMenuBarHelper = null;
+    createElectronTray();
+  });
+  helper.once("exit", (code, signal) => {
+    if (macMenuBarHelper !== helper) return;
+    macMenuBarHelper = null;
+    if (isQuitting) return;
+    console.error(`Native macOS menu bar helper exited (${code ?? signal ?? "unknown"})`);
+    createElectronTray();
+  });
+  return true;
+}
+
+function handleMacMenuBarHelperEvent(message: string) {
+  const [eventName, appKitX, appKitY] = message.split("\t");
+  const x = Number(appKitX);
+  const y = Number(appKitY);
+  if (Number.isFinite(x) && Number.isFinite(y)) {
+    const primaryBounds = screen.getPrimaryDisplay().bounds;
+    lastMacMenuBarPoint = {
+      x: Math.round(x),
+      y: Math.round(primaryBounds.y + primaryBounds.height - y),
+    };
+  } else {
+    lastMacMenuBarPoint = screen.getCursorScreenPoint();
+  }
+  if (eventName === "left-click") {
+    toggleMenuBarPopover();
+    return;
+  }
+  if (eventName !== "right-click") return;
+  hideMenuBarPopover();
+  refreshTrayMenu();
+  showTrayContextMenu();
+}
+
+function showTrayContextMenu() {
+  if (!trayContextMenu) return;
+  if (tray) {
+    tray.popUpContextMenu(trayContextMenu);
+    return;
+  }
+  const point = lastMacMenuBarPoint ?? screen.getCursorScreenPoint();
+  trayContextMenu.popup({ x: point.x, y: point.y });
 }
 
 function createTrayIcon() {
@@ -1315,7 +1398,9 @@ function applyMenuBarWindowSpaceBehavior(window: BrowserWindow) {
 }
 
 function positionMenuBarWindow(window: BrowserWindow) {
-  const anchorBounds = tray?.getBounds();
+  const cursor = lastMacMenuBarPoint ?? screen.getCursorScreenPoint();
+  const anchorBounds = tray?.getBounds() ??
+    (macMenuBarHelper ? { x: cursor.x - 9, y: cursor.y - 9, width: 18, height: 18 } : undefined);
   if (!anchorBounds) return;
   const display = screen.getDisplayMatching(anchorBounds);
   const workArea = display.workArea;
@@ -1448,7 +1533,6 @@ function totalUnitMenuItems(): MenuItemConstructorOptions[] {
 }
 
 function refreshTrayMenu() {
-  if (!tray) return;
   const trayStats = getTrayStats();
   trayContextMenu = Menu.buildFromTemplate([
     {
@@ -1574,8 +1658,8 @@ function refreshTrayMenu() {
       click: () => app.quit(),
     },
   ]);
-  tray.setContextMenu(process.platform === "darwin" ? null : trayContextMenu);
-  tray.setToolTip(`${APP_NAME} · Lv.${trayStats.level} · ${trayStats.weatherLabel}`);
+  tray?.setContextMenu(process.platform === "darwin" ? null : trayContextMenu);
+  tray?.setToolTip(`${APP_NAME} · Lv.${trayStats.level} · ${trayStats.weatherLabel}`);
 }
 
 function updateTrayMenuLabel() {
@@ -1587,13 +1671,13 @@ function updateTrayMenuLabel() {
 }
 
 function reopenTrayMenuSoon(delayMs = 120) {
-  if (!tray) return;
+  if (!tray && !macMenuBarHelper) return;
   if (trayMenuReopenTimer) clearTimeout(trayMenuReopenTimer);
   trayMenuReopenTimer = setTimeout(() => {
     trayMenuReopenTimer = null;
-    if (!tray) return;
+    if (!tray && !macMenuBarHelper) return;
     refreshTrayMenu();
-    if (trayContextMenu) tray.popUpContextMenu(trayContextMenu);
+    showTrayContextMenu();
   }, delayMs);
 }
 
@@ -3123,6 +3207,9 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", () => {
+  isQuitting = true;
+  macMenuBarHelper?.kill();
+  macMenuBarHelper = null;
   flushPendingUsageEntries();
   stopUsageWatchers();
   if (updateCheckTimer) clearTimeout(updateCheckTimer);

--- a/src/native/macosMenuBarHelper.swift
+++ b/src/native/macosMenuBarHelper.swift
@@ -1,0 +1,56 @@
+import AppKit
+import Darwin
+
+final class MenuBarController: NSObject {
+  private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+
+  init(iconPath: String) {
+    super.init()
+    guard let button = statusItem.button,
+          let image = NSImage(contentsOfFile: iconPath) else {
+      fatalError("Unable to load the Vibe Tree menu bar icon")
+    }
+
+    image.size = NSSize(width: 18, height: 18)
+    image.isTemplate = true
+    button.image = image
+    button.toolTip = "Vibe Tree"
+    button.target = self
+    button.action = #selector(handleClick)
+    button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+  }
+
+  @objc private func handleClick() {
+    let eventName = NSApp.currentEvent?.type == .rightMouseUp ? "right-click" : "left-click"
+    let point = NSEvent.mouseLocation
+    print("\(eventName)\t\(point.x)\t\(point.y)")
+    fflush(stdout)
+  }
+}
+
+if CommandLine.arguments.count == 3, CommandLine.arguments[1] == "--check" {
+  guard NSImage(contentsOfFile: CommandLine.arguments[2]) != nil else {
+    fputs("Unable to load the Vibe Tree menu bar icon\n", stderr)
+    exit(1)
+  }
+  print("macOS menu bar helper check passed")
+  exit(0)
+}
+
+guard CommandLine.arguments.count >= 3,
+      let parentPid = Int32(CommandLine.arguments[2]) else {
+  fputs("Usage: vibe-tree-menu-bar-helper <icon-path> <parent-pid>\n", stderr)
+  exit(2)
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
+let controller = MenuBarController(iconPath: CommandLine.arguments[1])
+
+Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+  if kill(parentPid, 0) != 0 {
+    NSApp.terminate(nil)
+  }
+}
+
+app.run()

--- a/updates/manifest.json
+++ b/updates/manifest.json
@@ -2,6 +2,37 @@
   "schemaVersion": 1,
   "versions": [
     {
+      "version": "0.8.2",
+      "publishedAt": "2026-07-15",
+      "fullReleaseUrl": "https://github.com/open-grove/vibe-tree/releases/tag/v0.8.2",
+      "title": {
+        "zh-CN": "Vibe Tree v0.8.2",
+        "en-US": "Vibe Tree v0.8.2"
+      },
+      "summary": {
+        "zh-CN": "修复部分新版 macOS 上，已经允许 Vibe Tree 显示在菜单栏，但小树入口仍然不可见的问题。",
+        "en-US": "Fixed the Vibe Tree menu bar entry remaining invisible on some recent macOS versions even when it was allowed in System Settings."
+      },
+      "highlights": {
+        "zh-CN": [
+          "菜单栏小树改用原生 macOS 状态项显示。",
+          "点击小树仍会打开原来的成长浮窗，右键菜单保持不变。"
+        ],
+        "en-US": [
+          "The menu bar tree now uses a native macOS status item.",
+          "Clicking the tree still opens the existing growth popover, and the context menu is unchanged."
+        ]
+      },
+      "privacy": {
+        "zh-CN": [
+          "本次更新只调整本机菜单栏显示，不改变同步或上传内容。"
+        ],
+        "en-US": [
+          "This update only changes the local menu bar display and does not change synced or uploaded data."
+        ]
+      }
+    },
+    {
       "version": "0.8.1",
       "publishedAt": "2026-07-15",
       "fullReleaseUrl": "https://github.com/open-grove/vibe-tree/releases/tag/v0.8.1",


### PR DESCRIPTION
## Summary

- use a native AppKit status item on macOS 26 and later so the Vibe Tree menu bar entry remains visible
- preserve the existing growth popover and context menu behavior
- publish the v0.8.2 version metadata, in-app announcement, changelog, and release notes

## Root cause

Electron's Tray status item could remain invisible on macOS 26 even when Vibe Tree was enabled in System Settings. A minimal native AppKit status item rendered correctly with the same icon, so this release uses the native status item on affected macOS versions and retains Electron Tray as the fallback elsewhere.

## Validation

- `npm run typecheck`
- `npm run verify:cloud-sync`
- `npm run verify:worker-api`
- `npm run test:mac-handoff`
- `npm run test:mac-start`
- `npm run package:mac`
- `npm run test:mac-package`
- `npm run smoke:electron`
- `git diff --check`
- manual macOS verification: menu bar icon visible and left click opens the existing popover
