### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
+## 2026-09-03 (v0.9.0)
+
 - Added DeepSeek Harness token tracking from append-only `session.jsonl` and concatenated `session.jsonl.zstd` files, with incremental scanning, restart-safe deduplication, source settings, and cloud-sync source preservation.
+- Replaced per-event shared-tree uploads with hourly usage buckets grouped by device, source, and model, reducing repeated cloud reads and writes while preserving local event history.
+- Added resumable bucket migration, paginated delta sync, quota-aware retry backoff, and durable replacement of legacy cloud mirrors.
+- Fixed manual sync resending unchanged buckets and large sync checkpoints dropping deletion signatures.
 
 ## 2026-07-15 (v0.8.2)
 

--- a/docs/2026-09-03_RELEASE_V0.9.0.md
+++ b/docs/2026-09-03_RELEASE_V0.9.0.md
@@ -1,0 +1,65 @@
+# Vibe Tree v0.9.0 发布文案
+
+目标版本：`v0.9.0`。
+
+这是 `v0.8.2` 之后的正式版本，新增 DeepSeek Harness Token 统计，并升级多设备同养小树的云同步协议。
+
+## App 内更新公告
+
+### Vibe Tree v0.9.0
+
+新增 DeepSeek Harness Token 统计，并让多设备同养小树的云同步更稳定、更节省服务端资源。
+
+- 自动读取 DeepSeek Harness 的本地用量记录，并展示 Token、模型和来源统计。
+- 多设备同养改为同步每小时聚合用量，只上传发生变化的部分。
+- 网络或服务端暂时失败后可以安全续传，并会按退避时间重试。
+- 覆盖升级会保留现有本机数据，不需要清空或重新加入排行榜。
+
+## GitHub Release Notes
+
+```md
+# Vibe Tree v0.9.0
+
+## Added
+
+- Added local DeepSeek Harness token tracking for append-only `session.jsonl` and concatenated `session.jsonl.zstd` usage records.
+- Added DeepSeek Harness source settings, model breakdowns, incremental scanning, and restart-safe deduplication.
+
+## Changed
+
+- Shared-tree sync now uploads deterministic hourly usage buckets grouped by device, source, and model instead of individual usage events.
+- Sync uploads only changed buckets, pulls remote history through paginated deltas, and coalesces automatic changes.
+- Bucket migration and checkpoints are resumable after partial failures.
+
+## Fixed
+
+- Removed repeated full-table D1 deduplication and aggregation scans that could exhaust the daily row-read quota under heavy sync traffic.
+- Fixed retry backoff being overridden by newly recorded usage.
+- Fixed manual sync resending every unchanged bucket.
+- Fixed large sync checkpoints dropping deletion signatures and legacy mirror replacements not being persisted locally.
+
+## Privacy
+
+- DeepSeek Harness sessions are read locally; prompts, replies, code files, local paths, and session text are not uploaded.
+- Shared-tree sync uploads hourly token aggregates grouped by device, source, and model rather than individual session events.
+
+## Compatibility
+
+- Updating in place keeps existing local data; there is no need to reset the app or rejoin the leaderboard.
+```
+
+## 发布前检查
+
+- `package.json` 和 `package-lock.json` 版本号为 `0.9.0`。
+- `updates/manifest.json` 首项为 `0.9.0`，发布链接指向 `v0.9.0`。
+- `npm run typecheck`
+- `npm run build`
+- `npm run test:mac-start`
+- `npm run test:mac-handoff`
+- `npm run package:mac`
+- `npm run test:mac-package`
+- `npm run smoke:electron`
+- `npm run verify:cloud-sync`
+- `npm run verify:renderer-ledger`
+- `npm run verify:worker-api`
+- `git diff --check`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-tree",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-tree",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "dependencies": {
         "html-to-image": "^1.11.13",
         "qrcode": "^1.5.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-tree",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "productName": "Vibe Tree",
   "private": true,
   "type": "module",

--- a/updates/manifest.json
+++ b/updates/manifest.json
@@ -2,6 +2,59 @@
   "schemaVersion": 1,
   "versions": [
     {
+      "version": "0.9.0",
+      "publishedAt": "2026-09-03",
+      "fullReleaseUrl": "https://github.com/open-grove/vibe-tree/releases/tag/v0.9.0",
+      "title": {
+        "zh-CN": "Vibe Tree v0.9.0",
+        "en-US": "Vibe Tree v0.9.0"
+      },
+      "summary": {
+        "zh-CN": "新增 DeepSeek Harness Token 统计，并让多设备同养小树的云同步更稳定、更节省服务端资源。",
+        "en-US": "Added DeepSeek Harness token tracking and made shared-tree cloud sync more reliable and resource-efficient."
+      },
+      "highlights": {
+        "zh-CN": [
+          "自动读取 DeepSeek Harness 的本地用量记录，并展示 Token、模型和来源统计。",
+          "多设备同养改为同步每小时聚合用量，只上传发生变化的部分。",
+          "网络或服务端暂时失败后可以安全续传，并会按退避时间重试。"
+        ],
+        "en-US": [
+          "Reads local DeepSeek Harness usage records and shows token, model, and source statistics.",
+          "Shared-tree sync now uploads hourly aggregates and only sends data that changed.",
+          "Interrupted syncs can resume safely and retry with backoff after network or server failures."
+        ]
+      },
+      "fixes": {
+        "zh-CN": [
+          "减少云同步中的重复读取、重复上传和无效重试，避免排行榜与同养小树服务在高用量时承受不必要的压力。",
+          "修复大量长期用量下，部分同步删除状态可能无法完整保留的问题。"
+        ],
+        "en-US": [
+          "Reduced repeated reads, uploads, and ineffective retries so leaderboard and shared-tree services avoid unnecessary load under heavy usage.",
+          "Fixed some deletion state not being retained after very large long-running sync histories."
+        ]
+      },
+      "privacy": {
+        "zh-CN": [
+          "DeepSeek Harness 会话记录只在本机读取，不会上传提示词、回复、代码文件、本地路径或会话正文。",
+          "多设备同养只同步按设备、来源和模型聚合的每小时 Token 用量，不上传单条会话事件。"
+        ],
+        "en-US": [
+          "DeepSeek Harness sessions are read locally; prompts, replies, code files, local paths, and session text are not uploaded.",
+          "Shared-tree sync uploads hourly token aggregates grouped by device, source, and model rather than individual session events."
+        ]
+      },
+      "upgradeNotes": {
+        "zh-CN": [
+          "覆盖升级会保留现有本机数据，不需要清空或重新加入排行榜。"
+        ],
+        "en-US": [
+          "Updating in place keeps existing local data; there is no need to reset the app or rejoin the leaderboard."
+        ]
+      }
+    },
+    {
       "version": "0.8.2",
       "publishedAt": "2026-07-15",
       "fullReleaseUrl": "https://github.com/open-grove/vibe-tree/releases/tag/v0.8.2",


### PR DESCRIPTION
## Summary

- release DeepSeek Harness local token tracking
- release protocol-v2 hourly aggregate cloud sync and the quota/load fixes from #54
- publish the v0.9.0 version metadata, in-app announcement, changelog, and release notes

## Validation

- npm run typecheck
- npm run build
- npm run verify:cloud-sync
- npm run verify:renderer-ledger
- npm run verify:worker-api
- Codex and DeepSeek watcher fixtures
- macOS start and handoff tests
- npm run package:mac
- npm run test:mac-package
- npm run smoke:electron
- git diff --check

## Distribution

The macOS candidate reports version 0.9.0, bundle identifier com.vibetree.app, and passes the repository ad-hoc signature verification.